### PR TITLE
[FEAT]  모든 엔티티 생성

### DIFF
--- a/src/main/java/com/ssmoker/smoker/domain/member/domain/Member.java
+++ b/src/main/java/com/ssmoker/smoker/domain/member/domain/Member.java
@@ -1,0 +1,43 @@
+package com.ssmoker.smoker.domain.member.domain;
+
+import com.ssmoker.smoker.domain.updatedHistory.domain.UpdatedHistory;
+import com.ssmoker.smoker.global.common.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class Member extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String nickName;
+
+    private Integer updateCount = 0;
+
+    private LocalDateTime deactivationDate;
+
+    @Enumerated(EnumType.STRING)
+    private MemberStatus status;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<UpdatedHistory> updatedHistories = new ArrayList<>();
+}

--- a/src/main/java/com/ssmoker/smoker/domain/member/domain/MemberStatus.java
+++ b/src/main/java/com/ssmoker/smoker/domain/member/domain/MemberStatus.java
@@ -1,0 +1,6 @@
+package com.ssmoker.smoker.domain.member.domain;
+
+public enum MemberStatus {
+    ACTIVE,
+    DEACTIVATED;
+}

--- a/src/main/java/com/ssmoker/smoker/domain/notice/domain/Notice.java
+++ b/src/main/java/com/ssmoker/smoker/domain/notice/domain/Notice.java
@@ -1,0 +1,28 @@
+package com.ssmoker.smoker.domain.notice.domain;
+
+import com.ssmoker.smoker.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class Notice extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+    
+    @Column(length = 1000, nullable = false)
+    private String content;
+}

--- a/src/main/java/com/ssmoker/smoker/domain/review/domain/Review.java
+++ b/src/main/java/com/ssmoker/smoker/domain/review/domain/Review.java
@@ -1,0 +1,39 @@
+package com.ssmoker.smoker.domain.review.domain;
+
+import com.ssmoker.smoker.domain.smokingArea.domain.SmokingArea;
+import com.ssmoker.smoker.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class Review extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "smoking_area_id", nullable = false)
+    private SmokingArea smokingArea;
+
+    @Column(nullable = false)
+    private Double score;
+
+    @Column(length = 1000, nullable = false)
+    private String content;
+
+    private String imageUrl;
+}

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/domain/Feature.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/domain/Feature.java
@@ -1,0 +1,25 @@
+package com.ssmoker.smoker.domain.smokingArea.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class Feature {
+    @Column(nullable = false)
+    private Boolean isEnclosedSmokingArea;
+
+    @Column(nullable = false)
+    private Boolean hasTrashBin;
+
+    @Column(nullable = false)
+    private Boolean hasChair;
+
+    @Column(nullable = false)
+    private Boolean hasAirConditioning;
+}

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/domain/Location.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/domain/Location.java
@@ -1,5 +1,6 @@
 package com.ssmoker.smoker.domain.smokingArea.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
@@ -11,9 +12,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Getter
 public class Location {
-
+    @Column(nullable = false)
     private Double latitude;
 
+    @Column(nullable = false)
     private Double longitude;
 
     // equals 사용을 위해 Override

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/domain/Location.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/domain/Location.java
@@ -1,0 +1,39 @@
+package com.ssmoker.smoker.domain.smokingArea.domain;
+
+import jakarta.persistence.Embeddable;
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class Location {
+
+    private Double latitude;
+
+    private Double longitude;
+
+    // equals 사용을 위해 Override
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Location location = (Location) o;
+        return Objects.equals(latitude, location.latitude) && Objects.equals(longitude,
+                location.longitude);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(latitude, longitude);
+    }
+
+    // 위도 경도 관련된 함수 (필요시)
+}

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/domain/SmokingArea.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/domain/SmokingArea.java
@@ -34,20 +34,11 @@ public class SmokingArea extends BaseEntity {
     @Embedded
     private Location location;
 
+    @Embedded
+    private Feature feature;
+
     @Column(nullable = false)
     private Boolean isApproved;
-
-    @Column(nullable = false)
-    private Boolean isEnclosedSmokingArea;
-
-    @Column(nullable = false)
-    private Boolean hasTrashBin;
-
-    @Column(nullable = false)
-    private Boolean hasChair;
-
-    @Column(nullable = false)
-    private Boolean hasAirConditioning;
 
     @OneToMany(mappedBy = "smokingArea", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Review> reviews = new ArrayList<>();

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/domain/SmokingArea.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/domain/SmokingArea.java
@@ -1,0 +1,57 @@
+package com.ssmoker.smoker.domain.smokingArea.domain;
+
+import com.ssmoker.smoker.domain.review.domain.Review;
+import com.ssmoker.smoker.domain.updatedHistory.domain.UpdatedHistory;
+import com.ssmoker.smoker.global.common.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class SmokingArea extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 20)
+    private String smokingAreaName;
+
+    @Embedded
+    private Location location;
+
+    @Column(nullable = false)
+    private Boolean isApproved;
+
+    @Column(nullable = false)
+    private Boolean isEnclosedSmokingArea;
+
+    @Column(nullable = false)
+    private Boolean hasTrashBin;
+
+    @Column(nullable = false)
+    private Boolean hasChair;
+
+    @Column(nullable = false)
+    private Boolean hasAirConditioning;
+
+    @OneToMany(mappedBy = "smokingArea", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Review> reviews = new ArrayList<>();
+
+    @OneToMany(mappedBy = "smokingArea", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<UpdatedHistory> updatedHistories = new ArrayList<>();
+}

--- a/src/main/java/com/ssmoker/smoker/domain/updatedHistory/domain/UpdatedHistory.java
+++ b/src/main/java/com/ssmoker/smoker/domain/updatedHistory/domain/UpdatedHistory.java
@@ -1,0 +1,37 @@
+package com.ssmoker.smoker.domain.updatedHistory.domain;
+
+import com.ssmoker.smoker.domain.member.domain.Member;
+import com.ssmoker.smoker.domain.smokingArea.domain.SmokingArea;
+import com.ssmoker.smoker.global.common.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class UpdatedHistory extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    //행위 ENUM 추가 ?
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @JoinColumn(name = "smoking_area_id", nullable = false)
+    private SmokingArea smokingArea;
+}

--- a/src/main/java/com/ssmoker/smoker/global/common/BaseEntity.java
+++ b/src/main/java/com/ssmoker/smoker/global/common/BaseEntity.java
@@ -1,0 +1,22 @@
+package com.ssmoker.smoker.global.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}
+


### PR DESCRIPTION
## 작업 내용

> 엔티티 세팅 했습니당

## 참고 사항

흡연 구역 지역 테이블이 흡연 구역 테이블과 분리되어 있었는데, 흡연 구역 테이블에 합쳐봤습니다.
> 위도와 경도를 처리하는 클래스를 사용하고 있어서, 이 클래스에 지역 데이터를 함께 넣는 방식도 괜찮은 것 같아서, 별도의 흡연 구역 지역 테이블은 생성하지 않았습니다

리뷰 테이블에 사용자와 연관 관계를 설정하지 않았습니다.
> 리뷰 수정 기능이 없어서 연관 관계를 설정하지 않았습니다.

멤버 엔티티는 마이페이지가 나오면 추가하면 될  것 같아요 ! 
## 연관 이슈

> close #1 


<br>