### PR TITLE
[Feat] 리뷰 조회 API 구현

### DIFF
--- a/src/main/java/com/ssmoker/smoker/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/ssmoker/smoker/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,16 @@
+package com.ssmoker.smoker.domain.review.repository;
+
+import com.ssmoker.smoker.domain.review.domain.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    @Query(
+            value = "SELECT r FROM Review r JOIN FETCH r.member WHERE r.smokingArea.id = :smokingAreaId ORDER BY r.createdAt DESC",
+            countQuery = "SELECT COUNT(r) FROM Review r WHERE r.smokingArea.id = :smokingAreaId"
+    )
+    Page<Review> findReviewsWithMemberById(@Param("smokingAreaId") Long smokingAreaId, PageRequest pageRequest);}

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/controller/SmokingAreaController.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/controller/SmokingAreaController.java
@@ -1,5 +1,6 @@
 package com.ssmoker.smoker.domain.smokingArea.controller;
 
+import com.ssmoker.smoker.domain.smokingArea.dto.ReviewResponses;
 import com.ssmoker.smoker.domain.smokingArea.service.SmokingAreaService;
 import com.ssmoker.smoker.domain.smokingArea.dto.SmokingAreaInfoResponse;
 import com.ssmoker.smoker.global.apiPayload.ApiResponse;
@@ -8,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -22,6 +24,14 @@ public class SmokingAreaController {
     @GetMapping("/{smokingAreaId}")
     public ApiResponse<SmokingAreaInfoResponse> getSmokingArea(@PathVariable Long smokingAreaId) {
         SmokingAreaInfoResponse result = smokingAreaService.getSmokingAreaInfo(smokingAreaId);
+
+        return ApiResponse.onSuccess(result);
+    }
+
+    @Operation(summary = "흡연 구역 리뷰 조회(최신순)", description = "쿼리 스트링으로 원하는 페이지를 넘겨주시면 됩니다.")
+    @GetMapping("/{smokingAreaId}/reviews")
+    public ApiResponse<ReviewResponses> getReviews(@PathVariable Long smokingAreaId, @RequestParam int pageNumber) {
+        ReviewResponses result = smokingAreaService.getReviews(smokingAreaId, pageNumber);
 
         return ApiResponse.onSuccess(result);
     }

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/dto/ReviewResponse.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/dto/ReviewResponse.java
@@ -1,0 +1,21 @@
+package com.ssmoker.smoker.domain.smokingArea.dto;
+
+import com.ssmoker.smoker.domain.review.domain.Review;
+import java.time.LocalDateTime;
+
+public record ReviewResponse (double score
+        , String content
+        , String imageUrl
+        , String memberName
+        , LocalDateTime creationDate) {
+
+    public static ReviewResponse of(final Review review,final String memberName) {
+        return new ReviewResponse(
+                review.getScore(),
+                review.getContent(),
+                review.getImageUrl(),
+                memberName,
+                review.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/dto/ReviewResponses.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/dto/ReviewResponses.java
@@ -1,0 +1,12 @@
+package com.ssmoker.smoker.domain.smokingArea.dto;
+
+import java.util.List;
+
+public record ReviewResponses(List<ReviewResponse> reviews,
+                              boolean isLastPage,
+                              int pageNumber) {
+
+    public static ReviewResponses of(List<ReviewResponse> reviews, boolean isLastPage, int pageNumber) {
+        return new ReviewResponses(reviews, isLastPage, pageNumber);
+    }
+}

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/dto/SmokingAreaInfoResponse.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/dto/SmokingAreaInfoResponse.java
@@ -7,8 +7,8 @@ import com.ssmoker.smoker.domain.smokingArea.domain.SmokingArea;
 public record SmokingAreaInfoResponse(String smokingAreaName
         , Location location
         , Feature feature) {
-    public static SmokingAreaInfoResponse of(SmokingArea smokingArea) {
 
+    public static SmokingAreaInfoResponse of(final SmokingArea smokingArea) {
         return new SmokingAreaInfoResponse(
                 smokingArea.getSmokingAreaName(),
                 smokingArea.getLocation(),

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/exception/ReviewPageNumberException.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/exception/ReviewPageNumberException.java
@@ -1,0 +1,10 @@
+package com.ssmoker.smoker.domain.smokingArea.exception;
+
+import com.ssmoker.smoker.global.exception.SmokerBadRequestException;
+import com.ssmoker.smoker.global.exception.code.BaseErrorCode;
+
+public class ReviewPageNumberException extends SmokerBadRequestException {
+    public ReviewPageNumberException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/service/SmokingAreaService.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/service/SmokingAreaService.java
@@ -1,21 +1,34 @@
 package com.ssmoker.smoker.domain.smokingArea.service;
 
+import static com.ssmoker.smoker.global.exception.code.ErrorStatus.REVIEW_BAD_REQUEST;
 import static com.ssmoker.smoker.global.exception.code.ErrorStatus.SMOKING_AREA_NOT_FOUND;
 
+import com.ssmoker.smoker.domain.review.domain.Review;
+import com.ssmoker.smoker.domain.review.repository.ReviewRepository;
 import com.ssmoker.smoker.domain.smokingArea.domain.SmokingArea;
+import com.ssmoker.smoker.domain.smokingArea.dto.ReviewResponse;
+import com.ssmoker.smoker.domain.smokingArea.dto.ReviewResponses;
+import com.ssmoker.smoker.domain.smokingArea.exception.ReviewPageNumberException;
 import com.ssmoker.smoker.domain.smokingArea.exception.SmokingAreaNotFoundException;
 import com.ssmoker.smoker.domain.smokingArea.repository.SmokingAreaRepository;
 import com.ssmoker.smoker.domain.smokingArea.dto.SmokingAreaInfoResponse;
 import com.ssmoker.smoker.global.exception.code.ErrorStatus;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class SmokingAreaService {
 
+    private static final int REVIEW_PAGE_SIZE = 5;
+
     private final SmokingAreaRepository smokingAreaRepository;
+    private final ReviewRepository reviewRepository;
 
     public SmokingAreaInfoResponse getSmokingAreaInfo(Long id) {
         Optional<SmokingArea> smokingArea = smokingAreaRepository.findById(id);
@@ -23,5 +36,27 @@ public class SmokingAreaService {
             return SmokingAreaInfoResponse.of(smokingArea.get());
         }
         throw new SmokingAreaNotFoundException(SMOKING_AREA_NOT_FOUND);
+    }
+
+    public ReviewResponses getReviews(Long id, int pageNumber) {
+        if (pageNumber < 0) {
+            throw new ReviewPageNumberException(REVIEW_BAD_REQUEST);
+        }
+        Page<Review> reviewPage = reviewRepository.findReviewsWithMemberById(id,
+                PageRequest.of(pageNumber, REVIEW_PAGE_SIZE));
+
+        ReviewResponses reviewResponses = ReviewResponses.of(getReviewResponses(reviewPage), reviewPage.isLast(),
+                reviewPage.getNumber());
+        return reviewResponses;
+    }
+
+    private List<ReviewResponse> getReviewResponses(Page<Review> reviewPage) {
+        return reviewPage.getContent().stream()
+                .map(this::getReviewResponse)
+                .collect(Collectors.toList());
+    }
+
+    private ReviewResponse getReviewResponse(Review review) {
+        return ReviewResponse.of(review, review.getMember().getNickName());
     }
 }

--- a/src/main/java/com/ssmoker/smoker/global/exception/code/ErrorStatus.java
+++ b/src/main/java/com/ssmoker/smoker/global/exception/code/ErrorStatus.java
@@ -9,20 +9,19 @@ import org.springframework.http.HttpStatus;
 public enum ErrorStatus implements BaseErrorCode {
     //Test
     TEST(HttpStatus.BAD_GATEWAY, "TEST2025", "예외 처리 테스트입니다."),
-
     // 가장 일반적인 응답
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
     _BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON400", "잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
-
     // Member
     // fixme: 예시라서 수정하셔도 됩니다 !
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
     NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER4002", "닉네임은 필수 입니다."),
-
+    // Review
+    REVIEW_BAD_REQUEST(HttpStatus.BAD_REQUEST, "REVIEW4001", "페이지 넘버는 0 이상이어야 합니다."),
     // SmokingArea
-    SMOKING_AREA_NOT_FOUND(HttpStatus.BAD_REQUEST, "AREA40001", "흡연 구역이 없습니다.");
+    SMOKING_AREA_NOT_FOUND(HttpStatus.BAD_REQUEST, "AREA4001", "흡연 구역이 없습니다.");
 
     // todo: 필요한 예외 추가
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 작업 내용

> 리뷰 조회 API 구현, paging 처리 (리뷰 5개 단위),
예외 처리

## 참고 사항

> 리뷰 관련 코드를 SmokingArea 디렉토리에 넣어도 좋을 것 같아요. 리뷰 수정이 없어서 리뷰만 사용하는 컨트롤러가 없어서 리뷰 디렉토리가 없어도 될 것 같기도 합니다.. ! 

## 연관 이슈

> close #13 


<br>