### PR TITLE
[Feat] 흡연 구역 지도 marker 표시

### DIFF
--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/controller/SmokingAreaController.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/controller/SmokingAreaController.java
@@ -1,9 +1,12 @@
 package com.ssmoker.smoker.domain.smokingArea.controller;
 
+import com.ssmoker.smoker.domain.smokingArea.dto.MapResponse;
 import com.ssmoker.smoker.domain.smokingArea.dto.ReviewResponses;
+import com.ssmoker.smoker.domain.smokingArea.dto.SmokingAreaMarkersResponse;
 import com.ssmoker.smoker.domain.smokingArea.service.SmokingAreaService;
 import com.ssmoker.smoker.domain.smokingArea.dto.SmokingAreaInfoResponse;
 import com.ssmoker.smoker.global.apiPayload.ApiResponse;
+import com.ssmoker.smoker.global.apiPayload.code.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -35,4 +38,25 @@ public class SmokingAreaController {
 
         return ApiResponse.onSuccess(result);
     }
+
+/*    //지도 api
+    @Operation(summary = "흡연 구역 지도_마커표시 위함",
+    description = "프론트가 지도에 마커표시를 할 수 있도록 흡연구역 db를 보내주는 역할")
+    @GetMapping
+    public ApiResponse<MapResponse.SmokingMarkersResponse> getSmokingAreaMakersInfo(){
+        MapResponse.SmokingMarkersResponse markers = smokingAreaService.getSmokingMarkersResponse();
+
+        return ApiResponse.of(SuccessStatus.MAP_INFO_OK, markers);
+    }*/
+
+/*    @Operation(summary = "흡연 구역 마커 클릭(모달)",
+    description = "흡연구역 마커 클릭 시 다른 작은 창으로 마커 정보 알려주는 역할")
+    @GetMapping("/{smokingAreaId}")
+    public ApiResponse<MapResponse.MarkerResponse> getSmokingAreaMarker(
+            @PathVariable(name = "smokingAreaId") Long smokingAreaId,
+            @RequestParam Double userLat,
+            @RequestParam Double userLng
+    ){
+
+    }*/
 }

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/controller/SmokingAreaController.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/controller/SmokingAreaController.java
@@ -39,7 +39,7 @@ public class SmokingAreaController {
         return ApiResponse.onSuccess(result);
     }
 
-/*    //지도 api
+   //지도 api
     @Operation(summary = "흡연 구역 지도_마커표시 위함",
     description = "프론트가 지도에 마커표시를 할 수 있도록 흡연구역 db를 보내주는 역할")
     @GetMapping
@@ -47,7 +47,7 @@ public class SmokingAreaController {
         MapResponse.SmokingMarkersResponse markers = smokingAreaService.getSmokingMarkersResponse();
 
         return ApiResponse.of(SuccessStatus.MAP_INFO_OK, markers);
-    }*/
+    }
 
 /*    @Operation(summary = "흡연 구역 마커 클릭(모달)",
     description = "흡연구역 마커 클릭 시 다른 작은 창으로 마커 정보 알려주는 역할")

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/domain/Location.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/domain/Location.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public class Location {
     @Column(nullable = false)
-    private String name;
+    private String address;
 
     @Column(nullable = false)
     private Double latitude;

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/domain/SmokingArea.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/domain/SmokingArea.java
@@ -37,8 +37,8 @@ public class SmokingArea extends BaseEntity {
     @Embedded
     private Feature feature;
 
-    @Column(nullable = false)
-    private Boolean isApproved;
+    /*@Column(nullable = false)
+    private Boolean isApproved;*/
 
     @OneToMany(mappedBy = "smokingArea", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Review> reviews = new ArrayList<>();

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/domain/SmokingArea.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/domain/SmokingArea.java
@@ -31,9 +31,6 @@ public class SmokingArea extends BaseEntity {
     @Column(nullable = false, length = 20)
     private String smokingAreaName;
 
-    @Column(nullable = false, length = 20)
-    private String address;
-    
     @Embedded
     private Location location;
 

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/domain/SmokingArea.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/domain/SmokingArea.java
@@ -31,6 +31,9 @@ public class SmokingArea extends BaseEntity {
     @Column(nullable = false, length = 20)
     private String smokingAreaName;
 
+    @Column(nullable = false, length = 20)
+    private String address;
+    
     @Embedded
     private Location location;
 

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/dto/MapResponse.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/dto/MapResponse.java
@@ -1,0 +1,26 @@
+package com.ssmoker.smoker.domain.smokingArea.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+public class MapResponse {
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class SmokingMarkersResponse{
+        private final List<SmokingAreaMarkersResponse> makers;
+    }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class MarkerResponse{
+        private final Double distance;
+        private final int reviewCount;
+        private final int savedCount;
+    }
+}

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/dto/SmokingAreaMarkersResponse.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/dto/SmokingAreaMarkersResponse.java
@@ -12,6 +12,5 @@ import lombok.Setter;
 public class SmokingAreaMarkersResponse {
     private Long smokingId;
     private String name;
-    private String address;
     private Location location;
 }

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/dto/SmokingAreaMarkersResponse.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/dto/SmokingAreaMarkersResponse.java
@@ -1,0 +1,17 @@
+package com.ssmoker.smoker.domain.smokingArea.dto;
+
+import com.ssmoker.smoker.domain.smokingArea.domain.Location;
+import com.ssmoker.smoker.domain.smokingArea.domain.SmokingArea;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@AllArgsConstructor
+public class SmokingAreaMarkersResponse {
+    private Long smokingId;
+    private String name;
+    private String address;
+    private Location location;
+}

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/repository/SmokingAreaRepository.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/repository/SmokingAreaRepository.java
@@ -1,8 +1,11 @@
 package com.ssmoker.smoker.domain.smokingArea.repository;
 
 import com.ssmoker.smoker.domain.smokingArea.domain.SmokingArea;
+import org.springframework.data.domain.Example;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 
 @Repository

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/service/SmokingAreaService.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/service/SmokingAreaService.java
@@ -6,12 +6,10 @@ import static com.ssmoker.smoker.global.exception.code.ErrorStatus.SMOKING_AREA_
 import com.ssmoker.smoker.domain.review.domain.Review;
 import com.ssmoker.smoker.domain.review.repository.ReviewRepository;
 import com.ssmoker.smoker.domain.smokingArea.domain.SmokingArea;
-import com.ssmoker.smoker.domain.smokingArea.dto.ReviewResponse;
-import com.ssmoker.smoker.domain.smokingArea.dto.ReviewResponses;
+import com.ssmoker.smoker.domain.smokingArea.dto.*;
 import com.ssmoker.smoker.domain.smokingArea.exception.ReviewPageNumberException;
 import com.ssmoker.smoker.domain.smokingArea.exception.SmokingAreaNotFoundException;
 import com.ssmoker.smoker.domain.smokingArea.repository.SmokingAreaRepository;
-import com.ssmoker.smoker.domain.smokingArea.dto.SmokingAreaInfoResponse;
 import com.ssmoker.smoker.global.exception.code.ErrorStatus;
 import java.util.List;
 import java.util.Optional;
@@ -59,4 +57,28 @@ public class SmokingAreaService {
     private ReviewResponse getReviewResponse(Review review) {
         return ReviewResponse.of(review, review.getMember().getNickName());
     }
+
+   /* //marker를 위한 모든 db 보내기
+    public MapResponse.SmokingMarkersResponse getSmokingMarkersResponse() {
+        List<SmokingArea> smokingAreas = smokingAreaRepository.findAll();
+
+        List<SmokingAreaMarkersResponse> markers =
+                smokingAreas.stream()
+                        .map(marker -> new SmokingAreaMarkersResponse(
+                                marker.getId(),
+                                marker.getSmokingAreaName(),
+                                marker.getAddress(),
+                                marker.getLocation()
+                        ))
+                        .collect(Collectors.toList());
+
+        return new MapResponse.SmokingMarkersResponse(markers);
+    }*/
+
+/*    public MapResponse.MarkerResponse getMarkerResponse(Long smokinAreaId,
+                                                        Double userLat,
+                                                        Double userLng) {
+        SmokingArea smokingArea = smokingAreaRepository.findById(smokinAreaId)
+                .orElse(throw new );
+    }*/
 }

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/service/SmokingAreaService.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/service/SmokingAreaService.java
@@ -58,7 +58,7 @@ public class SmokingAreaService {
         return ReviewResponse.of(review, review.getMember().getNickName());
     }
 
-   /* //marker를 위한 모든 db 보내기
+    //marker를 위한 모든 db 보내기
     public MapResponse.SmokingMarkersResponse getSmokingMarkersResponse() {
         List<SmokingArea> smokingAreas = smokingAreaRepository.findAll();
 
@@ -73,7 +73,7 @@ public class SmokingAreaService {
                         .collect(Collectors.toList());
 
         return new MapResponse.SmokingMarkersResponse(markers);
-    }*/
+    }
 
 /*    public MapResponse.MarkerResponse getMarkerResponse(Long smokinAreaId,
                                                         Double userLat,

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/service/SmokingAreaService.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/service/SmokingAreaService.java
@@ -67,7 +67,6 @@ public class SmokingAreaService {
                         .map(marker -> new SmokingAreaMarkersResponse(
                                 marker.getId(),
                                 marker.getSmokingAreaName(),
-                                marker.getLocation().getAddress(),
                                 marker.getLocation()
                         ))
                         .collect(Collectors.toList());

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/service/SmokingAreaService.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/service/SmokingAreaService.java
@@ -67,7 +67,7 @@ public class SmokingAreaService {
                         .map(marker -> new SmokingAreaMarkersResponse(
                                 marker.getId(),
                                 marker.getSmokingAreaName(),
-                                marker.getAddress(),
+                                marker.getLocation().getAddress(),
                                 marker.getLocation()
                         ))
                         .collect(Collectors.toList());

--- a/src/main/java/com/ssmoker/smoker/global/apiPayload/code/SuccessStatus.java
+++ b/src/main/java/com/ssmoker/smoker/global/apiPayload/code/SuccessStatus.java
@@ -15,7 +15,13 @@ public enum SuccessStatus implements BaseCode {
     USER_LOGIN_OK(HttpStatus.OK, "AUTH2001", "회원 로그인이 완료되었습니다."),
     USER_LOGOUT_OK(HttpStatus.OK, "AUTH2002", "회원 로그아웃이 완료되었습니다."),
     USER_DELETE_OK(HttpStatus.OK, "AUTH2003", "회원 탈퇴가 완료되었습니다."),
-    USER_REFRESH_OK(HttpStatus.OK, "AUTH2004", "토큰 재발급이 완료되었습니다.");
+    USER_REFRESH_OK(HttpStatus.OK, "AUTH2004", "토큰 재발급이 완료되었습니다."),
+
+    //map 관련
+    MAP_INFO_OK(HttpStatus.OK, "MAP2001", "마커를 위한 흡연 구역 모두를 불러왔습니다."),
+    MAP_MARKER_OK(HttpStatus.OK, "MAP2002", "거리 계산을 했습니다."),
+    MAP_LIST_OK(HttpStatus.OK, "MAP2003", "목록을 불러왔습니다."),
+    MAP_SEARCH_OK(HttpStatus.OK, "MAP2004", "검색이 완료되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/ssmoker/smoker/security/SecurityConfig.java
+++ b/src/main/java/com/ssmoker/smoker/security/SecurityConfig.java
@@ -33,8 +33,10 @@ public class SecurityConfig {
             "api/smoking-area/{smokingAreaId}/reviews", // 흡연 구역 리뷰 조회
             "api/updated_history/{smokingAreaId}", // 업데이트 히스토리 조회
             "api/smoking-area/{smokingAreaId}/rating_info", //총 별점 & 별점 개수 조회
-            "api/smoking-area/search", //흡연 구역 검색
+            "api/smoking-area", //흡연구역 마커 보이기
             "api/smoking-area/{smokingAreaIid}/simple", //흡연 구역 지도 마커 클릭했을 때 흡연 구역 정보 조회 (모달)
+            "api/smokin-area/list", //흡연구역 목록보기
+            "api/smoking-area/search", //흡연 구역 검색
             "/test/{status}", //테스트 컨트롤러
             //등등 추가 및 수정해주세요
             "/health",


### PR DESCRIPTION
## 작업 내용

> Location entity 에서 name -> address 로 명칭 변경

> SmokingArea entity 에서 isApproved column 삭제

> 프론트 쪽에서 흡연 구역 marker 표시를 위해 흡연 구역 db 정보 한 번에 보내주기 

> 토큰이 필요 없는 기능 : security config 에 경로 추가해둠

## 참고 사항

> 만약 흡연 구역 db 정보가 100개 이상이면 현재 위치 받아와서 UI에서 보이는 반경에서만의 흡연구역 db 보낼 수 있도록 수정해야 할 거임

## 연관 이슈

>feat#9


<br>