### PR TITLE
[Refactor] jwt 토큰 관련 수정 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/com/ssmoker/smoker/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ssmoker/smoker/domain/member/controller/MemberController.java
@@ -1,41 +1,13 @@
 package com.ssmoker.smoker.domain.member.controller;
 
-import com.ssmoker.smoker.domain.member.dto.AuthRequestDTO;
-import com.ssmoker.smoker.domain.member.dto.AuthResponseDTO;
 import com.ssmoker.smoker.domain.member.service.MemberService;
-import com.ssmoker.smoker.global.apiPayload.ApiResponse;
-import com.ssmoker.smoker.global.apiPayload.code.SuccessStatus;
-import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/auth")
+@RequestMapping("api/member")
 public class MemberController {
     private final MemberService memberService;
 
-    @ResponseStatus(code = HttpStatus.OK)
-    @Operation(summary = "카카오 로그인 API", description = "카카오 로그인 및 회원 가입을 진행하는 API입니다. 인가코드를 넘겨주세요")
-    @GetMapping("/login/kakao")
-    public ApiResponse<AuthResponseDTO.OAuthResponse> kakaoLogin(@RequestParam("code") String code) {
-        return ApiResponse.of(SuccessStatus.USER_LOGIN_OK, memberService.kakaoLogin(code));
-    } //카카오 로그인
-
-    @ResponseStatus(code = HttpStatus.OK)
-    @Operation(summary = "구글 로그인 API", description = "구글 로그인 및 회원 가입을 진행하는 API입니다. 인가코드를 넘겨주세요")
-    @GetMapping("/login/google")
-    public ApiResponse<AuthResponseDTO.OAuthResponse> googleLogin(@RequestParam("code") String code) {
-        return ApiResponse.of(SuccessStatus.USER_LOGIN_OK, memberService.GoogleLogin(code));
-    } //구글 로그인
-
-    @ResponseStatus(code = HttpStatus.OK)
-    @Operation(
-            summary = "JWT Access Token 재발급 API",
-            description = "Refresh Token을 검증하고 새로운 Access Token과 Refresh Token을 응답합니다.")
-    @PostMapping("/refresh")
-    public ApiResponse<AuthResponseDTO.TokenRefreshResponse> refresh(@RequestBody AuthRequestDTO.RefreshTokenDTO request) {
-        return ApiResponse.of(SuccessStatus.USER_REFRESH_OK, memberService.refresh(request.getRefreshToken()));
-    } // JWT Access Token 재발급
 }

--- a/src/main/java/com/ssmoker/smoker/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssmoker/smoker/domain/member/service/MemberService.java
@@ -1,15 +1,7 @@
 package com.ssmoker.smoker.domain.member.service;
 
-import com.ssmoker.smoker.domain.member.dto.AuthResponseDTO;
-import com.ssmoker.smoker.domain.member.dto.MemberResponseDTO;
 import com.ssmoker.smoker.domain.member.domain.Member;
 
 public interface MemberService {
     Member findMemberById(Long memberId);
-
-    AuthResponseDTO.OAuthResponse kakaoLogin(String code);
-
-    AuthResponseDTO.TokenRefreshResponse refresh(String refreshToken);
-
-    AuthResponseDTO.OAuthResponse GoogleLogin(String code);
 }

--- a/src/main/java/com/ssmoker/smoker/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/ssmoker/smoker/domain/member/service/MemberServiceImpl.java
@@ -65,7 +65,7 @@ public class MemberServiceImpl implements MemberService {
             Member member = queryMember.get();
             String accessToken = jwtTokenProvider.createAccessToken(member.getId());
             String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
-            memberRepository.save(member);
+
             return AuthConverter.toOAuthResponse(accessToken, refreshToken, member);
         } else {
             Member member = memberRepository.save(AuthConverter.kakaoToMember(kakaoProfile));
@@ -104,12 +104,13 @@ public class MemberServiceImpl implements MemberService {
             Member member = queryMember.get();
             String accessToken = jwtTokenProvider.createAccessToken(member.getId());
             String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
-            memberRepository.save(member);
+
             return AuthConverter.toOAuthResponse(accessToken, refreshToken, member);
         } else {
             Member member = memberRepository.save(AuthConverter.googleToMember(googleProfile));
             String accessToken = jwtTokenProvider.createAccessToken(member.getId());
             String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
+
             memberRepository.save(member);
             return AuthConverter.toOAuthResponse(accessToken, refreshToken, member);
         }

--- a/src/main/java/com/ssmoker/smoker/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/ssmoker/smoker/domain/member/service/MemberServiceImpl.java
@@ -1,33 +1,19 @@
 package com.ssmoker.smoker.domain.member.service;
 
-import com.ssmoker.smoker.domain.member.dto.AuthResponseDTO;
 import com.ssmoker.smoker.domain.member.domain.Member;
 import com.ssmoker.smoker.domain.member.repository.MemberRepository;
 import com.ssmoker.smoker.global.security.exception.AuthException;
 import com.ssmoker.smoker.global.exception.code.ErrorStatus;
-import com.ssmoker.smoker.global.security.authDTO.GoogleProfile;
-import com.ssmoker.smoker.global.security.authDTO.KakaoProfile;
-import com.ssmoker.smoker.global.security.authDTO.OAuthToken;
-import com.ssmoker.smoker.global.security.converter.AuthConverter;
-import com.ssmoker.smoker.global.security.provider.GoogleAuthProvider;
-import com.ssmoker.smoker.global.security.provider.JwtTokenProvider;
-import com.ssmoker.smoker.global.security.provider.KakaoAuthProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-
-import java.util.Optional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
-    private final JwtTokenProvider jwtTokenProvider;
-    private final KakaoAuthProvider kakaoAuthProvider;
-    private final GoogleAuthProvider googleAuthProvider;
 
     @Override
     public Member findMemberById(Long memberId) {
@@ -36,98 +22,5 @@ public class MemberServiceImpl implements MemberService {
                 .findById(memberId)
                 .orElseThrow(() -> new AuthException(ErrorStatus.USER_NOT_FOUND));
     } // 유저 찾기
-
-    @Override
-    @Transactional
-    public AuthResponseDTO.OAuthResponse kakaoLogin(String code) {
-        OAuthToken oAuthToken;
-        try {
-            oAuthToken = kakaoAuthProvider.requestToken(code);
-        } catch (Exception e){
-            throw new AuthException(ErrorStatus.AUTH_INVALID_CODE);
-        }
-
-        KakaoProfile kakaoProfile;
-        try {
-            kakaoProfile =
-                    kakaoAuthProvider.requestKakaoProfile(oAuthToken.getAccess_token());
-        }catch (Exception e){
-            throw new AuthException(ErrorStatus.INVALID_REQUEST_INFO_KAKAO);
-        }
-
-        // 유저 정보 받기
-        Optional<Member> queryMember =
-                memberRepository.findByEmail(
-                        kakaoProfile.getKakaoAccount().getEmail());
-
-        // 가입자 혹은 비가입자 체크해서 로그인 처리
-        if (queryMember.isPresent()) {
-            Member member = queryMember.get();
-            String accessToken = jwtTokenProvider.createAccessToken(member.getId());
-            String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
-
-            return AuthConverter.toOAuthResponse(accessToken, refreshToken, member);
-        } else {
-            Member member = memberRepository.save(AuthConverter.kakaoToMember(kakaoProfile));
-            String accessToken = jwtTokenProvider.createAccessToken(member.getId());
-            String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
-            memberRepository.save(member);
-            return AuthConverter.toOAuthResponse(accessToken, refreshToken, member);
-        }
-    } //카카오 로그인
-
-    @Override
-    @Transactional
-    public AuthResponseDTO.OAuthResponse GoogleLogin(String code) {
-        OAuthToken oAuthToken;
-        try {
-            oAuthToken = googleAuthProvider.requestToken(code);
-        } catch (Exception e){
-            throw new AuthException(ErrorStatus.AUTH_INVALID_CODE);
-        }
-
-        GoogleProfile googleProfile;
-        try {
-            googleProfile =
-                    googleAuthProvider.requestGoogleProfile(oAuthToken.getAccess_token());
-        }catch (Exception e){
-            throw new AuthException(ErrorStatus.INVALID_REQUEST_INFO_GOOGLE);
-        }
-
-        // 유저 정보 받기
-        Optional<Member> queryMember =
-                memberRepository.findByEmail(
-                        googleProfile.getEmail()); //이메일
-
-
-        if (queryMember.isPresent()) {
-            Member member = queryMember.get();
-            String accessToken = jwtTokenProvider.createAccessToken(member.getId());
-            String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
-
-            return AuthConverter.toOAuthResponse(accessToken, refreshToken, member);
-        } else {
-            Member member = memberRepository.save(AuthConverter.googleToMember(googleProfile));
-            String accessToken = jwtTokenProvider.createAccessToken(member.getId());
-            String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
-
-            memberRepository.save(member);
-            return AuthConverter.toOAuthResponse(accessToken, refreshToken, member);
-        }
-    } // 구글 로그인
-
-    @Override
-    @Transactional
-    public AuthResponseDTO.TokenRefreshResponse refresh(String refreshToken) {
-        jwtTokenProvider.isTokenValid(refreshToken);
-        Long id = jwtTokenProvider.getId(refreshToken);
-        Member member = memberRepository.findById(id)
-                .orElseThrow(() -> new AuthException(ErrorStatus.USER_NOT_FOUND));
-        String newAccessToken =
-                jwtTokenProvider.createAccessToken(id);
-        String newRefreshToken =
-                jwtTokenProvider.createRefreshToken(id);
-        return AuthConverter.toTokenRefreshResponse(newAccessToken, newRefreshToken);
-    } // 토큰 재발급
 
 }

--- a/src/main/java/com/ssmoker/smoker/domain/token/controller/TokenController.java
+++ b/src/main/java/com/ssmoker/smoker/domain/token/controller/TokenController.java
@@ -1,0 +1,35 @@
+package com.ssmoker.smoker.domain.token.controller;
+
+import com.ssmoker.smoker.global.security.authDTO.AuthResponseDTO.TokenResponse;
+import com.ssmoker.smoker.domain.token.service.TokenService;
+import com.ssmoker.smoker.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/token")
+public class TokenController {
+
+    private final TokenService tokenService;
+
+    @Operation(
+            summary = "JWT Access Token 재발급 API",
+            description = "Refresh Token 을 검증하고 새로운 Access Token 과 Refresh Token 을 응답합니다.")
+    @PostMapping("/reissue")
+    public ApiResponse<TokenResponse> reissueToken(final HttpServletRequest request) {
+        TokenResponse tokenResponse = tokenService.reissueToken(request);
+
+        return ApiResponse.onSuccess(tokenResponse);
+    }
+
+    @GetMapping("/logout")
+    public void logout(final HttpServletRequest request) {
+        tokenService.deleteToken(request);
+    }
+}

--- a/src/main/java/com/ssmoker/smoker/domain/token/domain/Token.java
+++ b/src/main/java/com/ssmoker/smoker/domain/token/domain/Token.java
@@ -1,0 +1,35 @@
+package com.ssmoker.smoker.domain.token.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Token {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String refreshToken;
+
+    @Column(nullable = false, unique = true)
+    private Long memberId;
+
+    public Token(final String refreshToken, final Long memberId) {
+        this.refreshToken = refreshToken;
+        this.memberId = memberId;
+    }
+
+    public void changeToken(final String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/ssmoker/smoker/domain/token/repository/TokenRepository.java
+++ b/src/main/java/com/ssmoker/smoker/domain/token/repository/TokenRepository.java
@@ -1,0 +1,10 @@
+package com.ssmoker.smoker.domain.token.repository;
+
+import com.ssmoker.smoker.domain.token.domain.Token;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TokenRepository extends JpaRepository<Token, Long> {
+    Optional<Token> findByRefreshToken(String refreshToken);
+    Optional<Token> findByMemberId(Long memberId);
+}

--- a/src/main/java/com/ssmoker/smoker/domain/token/service/TokenService.java
+++ b/src/main/java/com/ssmoker/smoker/domain/token/service/TokenService.java
@@ -1,0 +1,60 @@
+package com.ssmoker.smoker.domain.token.service;
+
+import static com.ssmoker.smoker.global.exception.code.ErrorStatus.NOT_CONTAIN_TOKEN;
+
+import com.ssmoker.smoker.global.security.authDTO.AuthResponseDTO.TokenResponse;
+import com.ssmoker.smoker.domain.token.domain.Token;
+import com.ssmoker.smoker.domain.token.repository.TokenRepository;
+import com.ssmoker.smoker.global.security.converter.AuthConverter;
+import com.ssmoker.smoker.global.security.exception.AuthException;
+import com.ssmoker.smoker.global.security.provider.JwtTokenProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TokenService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final TokenRepository tokenRepository;
+
+    public TokenResponse reissueToken(HttpServletRequest request) {
+        String refreshToken = jwtTokenProvider.extractToken(request);
+        Token token = getToken(refreshToken);
+
+        Long memberId = validateRefreshToken(refreshToken);
+        String newAccessToken = jwtTokenProvider.createAccessToken(memberId);
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(memberId);
+
+        // refreshToken 업데이트
+        token.changeToken(newRefreshToken);
+        return AuthConverter.toTokenRefreshResponse(newAccessToken, newRefreshToken);
+    }
+
+    public void deleteToken(HttpServletRequest request) {
+        String refreshToken = jwtTokenProvider.extractToken(request);
+        Token token = getToken(refreshToken);
+
+        tokenRepository.delete(token);
+    }
+
+    private Token getToken(String refreshToken) {
+        Optional<Token> token = tokenRepository.findByRefreshToken(refreshToken);
+        if (!token.isPresent()) {
+            throw new AuthException(NOT_CONTAIN_TOKEN);
+            // Logout 되어있는 상황
+        }
+        return token.get();
+    }
+
+
+    private Long validateRefreshToken(String refreshToken) {
+        jwtTokenProvider.isTokenValid(refreshToken);
+        Long memberId = jwtTokenProvider.getId(refreshToken);
+        return memberId;
+    }
+}

--- a/src/main/java/com/ssmoker/smoker/global/configuration/SecurityConfig.java
+++ b/src/main/java/com/ssmoker/smoker/global/configuration/SecurityConfig.java
@@ -25,18 +25,18 @@ public class SecurityConfig {
     private final JwtRequestFilter jwtRequestFilter;
 
     private static final String[] SECURITY_ALLOW_ARRAY  = { //인증 없이 접근 가능한 엔드 포인트
-            "api/auth/login/google", //구글 로그인
-            "api/auth/login/kakao", //카카오 로그인
-            "api/auth/refresh", //토큰 재발급
-            "api/member/notices", //공지사항
-            "api/smoking-area/{smokingAreaId}", //흡연 구역 상세 정보 조회
-            "api/smoking-area/{smokingAreaId}/reviews", // 흡연 구역 리뷰 조회
-            "api/updated_history/{smokingAreaId}", // 업데이트 히스토리 조회
-            "api/smoking-area/{smokingAreaId}/rating_info", //총 별점 & 별점 개수 조회
-            "api/smoking-area", //흡연구역 마커 보이기
-            "api/smoking-area/{smokingAreaIid}/simple", //흡연 구역 지도 마커 클릭했을 때 흡연 구역 정보 조회 (모달)
-            "api/smoking-area/list", //흡연구역 목록보기
-            "api/smoking-area/search", //흡연 구역 검색
+            "/api/auth/login/google", //구글 로그인
+            "/api/auth/login/kakao", //카카오 로그인
+            "/api/auth/refresh", //토큰 재발급
+            "/api/member/notices", //공지사항
+            "/api/smoking-area/{smokingAreaId}", //흡연 구역 상세 정보 조회
+            "/api/smoking-area/{smokingAreaId}/reviews", // 흡연 구역 리뷰 조회
+            "/api/updated_history/{smokingAreaId}", // 업데이트 히스토리 조회
+            "/api/smoking-area/{smokingAreaId}/rating_info", //총 별점 & 별점 개수 조회
+            "/api/smoking-area", //흡연구역 마커 보이기
+            "/api/smoking-area/{smokingAreaIid}/simple", //흡연 구역 지도 마커 클릭했을 때 흡연 구역 정보 조회 (모달)
+            "/api/smoking-area/list", //흡연구역 목록보기
+            "/api/smoking-area/search", //흡연 구역 검색
             "/test/{status}", //테스트 컨트롤러
             //등등 추가 및 수정해주세요
             "/health",
@@ -44,13 +44,16 @@ public class SecurityConfig {
             "/swagger-ui/**",
             "/swagger-resources/**",
             "/v3/api-docs/**",
+            "/webjars/**",
+            "/swagger-ui.html",
             "/login",
             "/refresh",
             "/actuator/prometheus",
             "/ws/**",
             "/topic/**",
             "/api/post/**",
-            "/api/recommend/**"
+            "/api/recommend/**",
+            "/favicon.ico"
     };
 
     @Bean

--- a/src/main/java/com/ssmoker/smoker/global/exception/code/ErrorStatus.java
+++ b/src/main/java/com/ssmoker/smoker/global/exception/code/ErrorStatus.java
@@ -24,6 +24,9 @@ public enum ErrorStatus implements BaseErrorCode {
     SMOKING_AREA_NOT_FOUND(HttpStatus.BAD_REQUEST, "AREA4001", "흡연 구역이 없습니다."),
 
     // Auth 관련
+    AUTH_EXTRACT_ERROR_TEST(HttpStatus.UNAUTHORIZED, "AUTH_000TSET", "토큰 추출에 실패했습니다TEST."),
+
+    AUTH_EXTRACT_ERROR(HttpStatus.UNAUTHORIZED, "AUTH_000", "토큰 추출에 실패했습니다."),
     AUTH_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_001", "토큰이 만료되었습니다."),
     AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_002", "토큰이 유효하지 않습니다."),
     INVALID_LOGIN_REQUEST(HttpStatus.UNAUTHORIZED, "AUTH_003", "올바른 아이디나 패스워드가 아닙니다."),

--- a/src/main/java/com/ssmoker/smoker/global/security/authDTO/AuthRequestDTO.java
+++ b/src/main/java/com/ssmoker/smoker/global/security/authDTO/AuthRequestDTO.java
@@ -1,4 +1,4 @@
-package com.ssmoker.smoker.domain.member.dto;
+package com.ssmoker.smoker.global.security.authDTO;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;

--- a/src/main/java/com/ssmoker/smoker/global/security/authDTO/AuthResponseDTO.java
+++ b/src/main/java/com/ssmoker/smoker/global/security/authDTO/AuthResponseDTO.java
@@ -1,4 +1,4 @@
-package com.ssmoker.smoker.domain.member.dto;
+package com.ssmoker.smoker.global.security.authDTO;
 
 import lombok.*;
 
@@ -17,7 +17,7 @@ public class AuthResponseDTO {
     @Builder
     @AllArgsConstructor(access = AccessLevel.PROTECTED)
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class TokenRefreshResponse {
+    public static class TokenResponse {
         String accessToken;
         String refreshToken;
     }

--- a/src/main/java/com/ssmoker/smoker/global/security/controller/AuthController.java
+++ b/src/main/java/com/ssmoker/smoker/global/security/controller/AuthController.java
@@ -1,0 +1,37 @@
+package com.ssmoker.smoker.global.security.controller;
+
+import com.ssmoker.smoker.global.security.authDTO.AuthResponseDTO;
+import com.ssmoker.smoker.global.security.authDTO.AuthResponseDTO.OAuthResponse;
+import com.ssmoker.smoker.global.apiPayload.ApiResponse;
+import com.ssmoker.smoker.global.apiPayload.code.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @ResponseStatus(code = HttpStatus.OK)
+    @Operation(summary = "카카오 로그인 API", description = "카카오 로그인 및 회원 가입을 진행하는 API입니다. 인가코드를 넘겨주세요")
+    @GetMapping("/login/kakao")
+    public ApiResponse<OAuthResponse> kakaoLogin(@RequestParam("code") String code) {
+        return ApiResponse.of(SuccessStatus.USER_LOGIN_OK, authService.kakaoLogin(code));
+    } //카카오 로그인
+
+    @ResponseStatus(code = HttpStatus.OK)
+    @Operation(summary = "구글 로그인 API", description = "구글 로그인 및 회원 가입을 진행하는 API입니다. 인가코드를 넘겨주세요")
+    @GetMapping("/login/google")
+    public ApiResponse<AuthResponseDTO.OAuthResponse> googleLogin(@RequestParam("code") String code) {
+        return ApiResponse.of(SuccessStatus.USER_LOGIN_OK, authService.GoogleLogin(code));
+    } //구글 로그인
+
+}

--- a/src/main/java/com/ssmoker/smoker/global/security/controller/AuthService.java
+++ b/src/main/java/com/ssmoker/smoker/global/security/controller/AuthService.java
@@ -1,0 +1,131 @@
+package com.ssmoker.smoker.global.security.controller;
+
+import com.ssmoker.smoker.domain.member.domain.Member;
+import com.ssmoker.smoker.domain.token.domain.Token;
+import com.ssmoker.smoker.domain.token.repository.TokenRepository;
+import com.ssmoker.smoker.domain.member.repository.MemberRepository;
+import com.ssmoker.smoker.global.exception.code.ErrorStatus;
+import com.ssmoker.smoker.global.security.authDTO.AuthResponseDTO;
+import com.ssmoker.smoker.global.security.authDTO.AuthResponseDTO.OAuthResponse;
+import com.ssmoker.smoker.global.security.authDTO.GoogleProfile;
+import com.ssmoker.smoker.global.security.authDTO.KakaoProfile;
+import com.ssmoker.smoker.global.security.authDTO.OAuthToken;
+import com.ssmoker.smoker.global.security.converter.AuthConverter;
+import com.ssmoker.smoker.global.security.exception.AuthException;
+import com.ssmoker.smoker.global.security.provider.GoogleAuthProvider;
+import com.ssmoker.smoker.global.security.provider.JwtTokenProvider;
+import com.ssmoker.smoker.global.security.provider.KakaoAuthProvider;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final TokenRepository tokenRepository;
+    private final MemberRepository memberRepository;
+    private final KakaoAuthProvider kakaoAuthProvider;
+    private final GoogleAuthProvider googleAuthProvider;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    //카카오 로그인
+    @Transactional
+    public AuthResponseDTO.OAuthResponse kakaoLogin(String code) {
+        OAuthToken oAuthToken = getKakaoOauthToken(code);
+
+        KakaoProfile kakaoProfile;
+        try {
+            kakaoProfile =
+                    kakaoAuthProvider.requestKakaoProfile(oAuthToken.getAccess_token());
+        } catch (Exception e) {
+            throw new AuthException(ErrorStatus.INVALID_REQUEST_INFO_KAKAO);
+        }
+
+        // 유저 정보 받기
+        Optional<Member> queryMember =
+                memberRepository.findByEmail(
+                        kakaoProfile.getKakaoAccount().getEmail());
+
+
+        // 가입자 혹은 비가입자 체크해서 로그인 처리
+        if (queryMember.isPresent()) {
+            Member member = queryMember.get();
+            return getOauthResponseForPresentUser(member, queryMember);
+        }
+        Member member = memberRepository.save(AuthConverter.kakaoToMember(kakaoProfile));
+        return getOauthResponseForNewUser(member);
+    }
+
+    // 구글 로그인
+    @Transactional
+    public AuthResponseDTO.OAuthResponse GoogleLogin(String code) {
+        OAuthToken oAuthToken = getGooleOauthToken(code);
+
+        GoogleProfile googleProfile;
+        try {
+            googleProfile =
+                    googleAuthProvider.requestGoogleProfile(oAuthToken.getAccess_token());
+        } catch (Exception e) {
+            throw new AuthException(ErrorStatus.INVALID_REQUEST_INFO_GOOGLE);
+        }
+
+        // 유저 정보 받기
+        Optional<Member> queryMember =
+                memberRepository.findByEmail(
+                        googleProfile.getEmail()); //이메일
+
+        // 가입자 혹은 비가입자 체크해서 로그인 처리
+        if (queryMember.isPresent()) {
+            Member member = queryMember.get();
+            return getOauthResponseForPresentUser(member, queryMember);
+        }
+        Member member = memberRepository.save(AuthConverter.googleToMember(googleProfile));
+        return getOauthResponseForNewUser(member);
+    }
+
+    private OAuthResponse getOauthResponseForNewUser(Member member) {
+        String accessToken = jwtTokenProvider.createAccessToken(member.getId());
+        String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
+        saveNewMember(refreshToken, member);
+        return AuthConverter.toOAuthResponse(accessToken, refreshToken, member);
+    }
+
+    private OAuthResponse getOauthResponseForPresentUser(Member member, Optional<Member> queryMember) {
+        String accessToken = jwtTokenProvider.createAccessToken(member.getId());
+        String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
+        Optional<Token> savedRefreshToken = tokenRepository.findByMemberId(member.getId());
+        if (savedRefreshToken.isPresent()) {
+            savedRefreshToken.get().changeToken(refreshToken);
+        } else {
+            tokenRepository.save(new Token(refreshToken, member.getId()));
+        }
+        return AuthConverter.toOAuthResponse(accessToken, refreshToken, queryMember.get());
+    }
+
+    private void saveNewMember(String refreshToken, Member member) {
+        tokenRepository.save(new Token(refreshToken, member.getId()));
+        memberRepository.save(member);
+    }
+
+    private OAuthToken getGooleOauthToken(String code) {
+        OAuthToken oAuthToken;
+        try {
+            oAuthToken = googleAuthProvider.requestToken(code);
+        } catch (Exception e) {
+            throw new AuthException(ErrorStatus.AUTH_INVALID_CODE);
+        }
+        return oAuthToken;
+    }
+
+    private OAuthToken getKakaoOauthToken(String code) {
+        OAuthToken oAuthToken;
+        try {
+            oAuthToken = kakaoAuthProvider.requestToken(code);
+        } catch (Exception e) {
+            throw new AuthException(ErrorStatus.AUTH_INVALID_CODE);
+        }
+        return oAuthToken;
+    }
+}

--- a/src/main/java/com/ssmoker/smoker/global/security/converter/AuthConverter.java
+++ b/src/main/java/com/ssmoker/smoker/global/security/converter/AuthConverter.java
@@ -2,7 +2,8 @@ package com.ssmoker.smoker.global.security.converter;
 
 import com.ssmoker.smoker.domain.member.domain.Member;
 import com.ssmoker.smoker.domain.member.domain.MemberStatus;
-import com.ssmoker.smoker.domain.member.dto.AuthResponseDTO;
+import com.ssmoker.smoker.global.security.authDTO.AuthResponseDTO;
+import com.ssmoker.smoker.global.security.authDTO.AuthResponseDTO.TokenResponse;
 import com.ssmoker.smoker.global.security.authDTO.GoogleProfile;
 import com.ssmoker.smoker.global.security.authDTO.KakaoProfile;
 
@@ -33,9 +34,9 @@ public class AuthConverter {
                 .build();
     }
 
-    public static AuthResponseDTO.TokenRefreshResponse toTokenRefreshResponse(
+    public static TokenResponse toTokenRefreshResponse(
             String accessToken, String refreshToken) {
-        return AuthResponseDTO.TokenRefreshResponse.builder()
+        return TokenResponse.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();

--- a/src/main/java/com/ssmoker/smoker/global/security/filter/JwtRequestFilter.java
+++ b/src/main/java/com/ssmoker/smoker/global/security/filter/JwtRequestFilter.java
@@ -27,31 +27,37 @@ public class JwtRequestFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(
             HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-            throws IOException {
+            throws IOException, ServletException {
+
+        String path = request.getRequestURI();
+
+        // 1) 만약 Swagger, 로그인 등 "인증이 필요 없는 경로"이면 → 토큰 검증 스킵
+        if (isPermitAllPath(path)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         try {
-            String authorizationHeader = request.getHeader("Authorization");
+            String token = jwtTokenProvider.extractToken(request);
 
-            if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
-                String token = authorizationHeader.substring(7);
+            if (jwtTokenProvider.isTokenValid(token)) {
+                Long userId = jwtTokenProvider.getId(token);
+                UserDetails userDetails =
+                        principalDetailsService.loadUserByUsername(userId.toString());
 
-                if (jwtTokenProvider.isTokenValid(token)) {
-                    Long userId = jwtTokenProvider.getId(token);
-                    UserDetails userDetails =
-                            principalDetailsService.loadUserByUsername(userId.toString());
-
-                    if (userDetails != null) {
-                        UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
-                                new UsernamePasswordAuthenticationToken(
-                                        userDetails, "", userDetails.getAuthorities());
-                        SecurityContextHolder.getContext()
-                                .setAuthentication(usernamePasswordAuthenticationToken);
-                    } else { //유저 없음
-                        throw new AuthException(ErrorStatus.USER_NOT_FOUND);
-                    }
-                } else { //토큰이 유효하지 않음
-                    throw new AuthException(ErrorStatus.AUTH_INVALID_TOKEN);
+                if (userDetails != null) {
+                    UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+                            new UsernamePasswordAuthenticationToken(
+                                    userDetails, "", userDetails.getAuthorities());
+                    SecurityContextHolder.getContext()
+                            .setAuthentication(usernamePasswordAuthenticationToken);
+                } else { //유저 없음
+                    throw new AuthException(ErrorStatus.USER_NOT_FOUND);
                 }
+            } else { //토큰이 유효하지 않음
+                throw new AuthException(ErrorStatus.AUTH_INVALID_TOKEN);
             }
+
             filterChain.doFilter(request, response);
         } catch (AuthException ex) {
             setJsonResponse(response, ex.getErrorReasonHttpStatus().getHttpStatus().value(),
@@ -69,7 +75,22 @@ public class JwtRequestFilter extends OncePerRequestFilter {
             throws IOException {
         response.setStatus(statusCode);
         response.setContentType("application/json;charset=UTF-8");
-        String jsonResponse = String.format("{\"isSuccess\": false, \"code\": \"%s\", \"message\": \"%s\"}", code, message);
+        String jsonResponse = String.format("{\"isSuccess\": false, \"code\": \"%s\", \"message\": \"%s\"}", code,
+                message);
         response.getWriter().write(jsonResponse);
+    }
+
+    private boolean isPermitAllPath(String path) {
+        return path.startsWith("/swagger-ui")
+                || path.startsWith("/v3/api-docs")
+                || path.startsWith("/swagger-resources")
+                || path.startsWith("/webjars")
+                || path.equals("/swagger-ui.html")
+
+                // 로그인/토큰발급 등등
+                || path.startsWith("/api/auth/login/")
+                // 필요하다면 다른 permitAll 경로들도 추가
+                // ...
+                ;
     }
 }

--- a/src/main/java/com/ssmoker/smoker/global/security/handler/resolver/AuthUserArgumentResolver.java
+++ b/src/main/java/com/ssmoker/smoker/global/security/handler/resolver/AuthUserArgumentResolver.java
@@ -18,7 +18,6 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 @Component
 @RequiredArgsConstructor
 public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
-    private final MemberService memberService;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## 작업 내용

> refresh token을 서버에서 관리하여  access token이 만료되었을 때를 대비한다.

> JWT 인증 플로우

 1. 회원 가입 후 첫 로그인 (Case 1)
- **액션**: 
  - JWT Access Token 생성 후 프론트엔드로 제공.
  - 서버에 Refresh Token과 사용자(Member) 정보 저장.

 2. 기존 회원 로그인 (Case 2)
- **액션**: 
  - JWT Access Token 생성.
  - 기존에 저장된 Refresh Token을 새로 생성된 값으로 업데이트.

 3. 로그아웃
- **액션**: 
  - 서버에서 Refresh Token 삭제.
  - 프론트에서 Access Token 및 Refresh Token 삭제.

 4. 중복 로그인
  - 아직 구현하지 않음, 중복 로그인 어떻게 처리할까요 ? ? 

## 참고 사항

> 없습니다 ~

## 연관 이슈

> close #24 


<br>