### PR TITLE
[Feat] 상세 페이지 - 별점 평균, 개수 , 별점 별 개수 조회 api 구현한다. 

### DIFF
--- a/src/main/java/com/ssmoker/smoker/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/ssmoker/smoker/domain/review/controller/ReviewController.java
@@ -31,8 +31,8 @@ public class ReviewController {
     }
 
     @Operation(summary = "흡연 구역 상세 페이지 - 총 별점 및 별점 개수 조회",
-            description = "흡연 구역 별 별점 평균 및 전체 별점 조회")
-    @GetMapping("/{smokingAreaId}/stars")
+            description = "흡연 구역 별 별점 평균 및 전체 별점 조회입니다. 전체 별점은 리스트로 1->5 점으로 개수가 반환됩니다.")
+    @GetMapping("/{smokingAreaId}/starInfo")
     public ApiResponse<ReviewStarsInfoResponse> getSmokingAreaStarInfo(@PathVariable Long smokingAreaId) {
         ReviewStarsInfoResponse result = reviewService.getStarsInfoBySmokingAreaId(smokingAreaId);
 

--- a/src/main/java/com/ssmoker/smoker/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/ssmoker/smoker/domain/review/controller/ReviewController.java
@@ -1,5 +1,6 @@
 package com.ssmoker.smoker.domain.review.controller;
 
+import com.ssmoker.smoker.domain.review.dto.ReviewStarsInfoResponse;
 import com.ssmoker.smoker.domain.review.service.ReviewService;
 import com.ssmoker.smoker.domain.review.dto.ReviewResponses;
 import com.ssmoker.smoker.global.apiPayload.ApiResponse;
@@ -9,20 +10,31 @@ import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/reviews/")
 public class ReviewController {
 
     private final ReviewService reviewService;
 
-    @Operation(summary = "흡연 구역 리뷰 조회(최신순)", description = "쿼리 스트링으로 원하는 페이지를 넘겨주시면 됩니다.")
-    @GetMapping("/{smokingAreaId}/reviews")
+    @Operation(summary = "흡연 구역 상세 페이지 - 리뷰 조회(최신순)", description = "쿼리 스트링으로 원하는 페이지를 넘겨주시면 됩니다.")
+    @GetMapping("/{smokingAreaId}")
     public ApiResponse<ReviewResponses> getReviews(@PathVariable Long smokingAreaId,
                                                    @RequestParam @Min(0) @NotNull Integer pageNumber) {
-        ReviewResponses result = reviewService.getReviewsByAreaId(smokingAreaId, pageNumber);
+        ReviewResponses result = reviewService.getReviewsBySmokingAreaId(smokingAreaId, pageNumber);
+
+        return ApiResponse.onSuccess(result);
+    }
+
+    @Operation(summary = "흡연 구역 상세 페이지 - 총 별점 및 별점 개수 조회",
+            description = "흡연 구역 별 별점 평균 및 전체 별점 조회")
+    @GetMapping("/{smokingAreaId}/stars")
+    public ApiResponse<ReviewStarsInfoResponse> getSmokingAreaStarInfo(@PathVariable Long smokingAreaId) {
+        ReviewStarsInfoResponse result = reviewService.getStarsInfoBySmokingAreaId(smokingAreaId);
 
         return ApiResponse.onSuccess(result);
     }

--- a/src/main/java/com/ssmoker/smoker/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/ssmoker/smoker/domain/review/controller/ReviewController.java
@@ -1,0 +1,29 @@
+package com.ssmoker.smoker.domain.review.controller;
+
+import com.ssmoker.smoker.domain.review.service.ReviewService;
+import com.ssmoker.smoker.domain.review.dto.ReviewResponses;
+import com.ssmoker.smoker.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    @Operation(summary = "흡연 구역 리뷰 조회(최신순)", description = "쿼리 스트링으로 원하는 페이지를 넘겨주시면 됩니다.")
+    @GetMapping("/{smokingAreaId}/reviews")
+    public ApiResponse<ReviewResponses> getReviews(@PathVariable Long smokingAreaId,
+                                                   @RequestParam @Min(0) @NotNull Integer pageNumber) {
+        ReviewResponses result = reviewService.getReviewsByAreaId(smokingAreaId, pageNumber);
+
+        return ApiResponse.onSuccess(result);
+    }
+}

--- a/src/main/java/com/ssmoker/smoker/domain/review/dto/ReviewResponse.java
+++ b/src/main/java/com/ssmoker/smoker/domain/review/dto/ReviewResponse.java
@@ -1,4 +1,4 @@
-package com.ssmoker.smoker.domain.smokingArea.dto;
+package com.ssmoker.smoker.domain.review.dto;
 
 import com.ssmoker.smoker.domain.review.domain.Review;
 import java.time.LocalDateTime;

--- a/src/main/java/com/ssmoker/smoker/domain/review/dto/ReviewResponses.java
+++ b/src/main/java/com/ssmoker/smoker/domain/review/dto/ReviewResponses.java
@@ -1,4 +1,4 @@
-package com.ssmoker.smoker.domain.smokingArea.dto;
+package com.ssmoker.smoker.domain.review.dto;
 
 import java.util.List;
 

--- a/src/main/java/com/ssmoker/smoker/domain/review/dto/ReviewStarsInfoResponse.java
+++ b/src/main/java/com/ssmoker/smoker/domain/review/dto/ReviewStarsInfoResponse.java
@@ -2,5 +2,5 @@ package com.ssmoker.smoker.domain.review.dto;
 
 import java.util.List;
 
-public record ReviewStarsInfoResponse(List<Double> stars, double avg, int count) {
+public record ReviewStarsInfoResponse(List<Integer> stars, double avg, int count) {
 }

--- a/src/main/java/com/ssmoker/smoker/domain/review/dto/ReviewStarsInfoResponse.java
+++ b/src/main/java/com/ssmoker/smoker/domain/review/dto/ReviewStarsInfoResponse.java
@@ -1,0 +1,6 @@
+package com.ssmoker.smoker.domain.review.dto;
+
+import java.util.List;
+
+public record ReviewStarsInfoResponse(List<Double> stars, double avg, int count) {
+}

--- a/src/main/java/com/ssmoker/smoker/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/ssmoker/smoker/domain/review/repository/ReviewRepository.java
@@ -2,6 +2,7 @@ package com.ssmoker.smoker.domain.review.repository;
 
 import com.ssmoker.smoker.domain.review.domain.Review;
 import com.ssmoker.smoker.domain.review.dto.ReviewStarsInfoResponse;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -19,10 +20,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query("SELECT coalesce(avg(r.score), 0) FROM Review r WHERE r.smokingArea.id = :smokingAreaId")
     Double findAvgScoreBySmokingId(@Param("smokingAreaId") Long smokingAreaId);
 
-    @Query("SELECT new com.ssmoker.smoker.domain.review.dto.ReviewStarsInfoResponse(" +
-            "collect(r.score), " +
-            "avg(r.score), " +
-            "count(r.score))" +
+    @Query("SELECT r.score " +
             "FROM Review r WHERE r.smokingArea.id = :smokingAreaId")
-    ReviewStarsInfoResponse findStarsInfoBySmokingAreaId(Long smokingAreaId);
+    List<Double> findScoresBySmokingAreaId(Long smokingAreaId);
 }

--- a/src/main/java/com/ssmoker/smoker/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/ssmoker/smoker/domain/review/repository/ReviewRepository.java
@@ -1,6 +1,7 @@
 package com.ssmoker.smoker.domain.review.repository;
 
 import com.ssmoker.smoker.domain.review.domain.Review;
+import com.ssmoker.smoker.domain.review.dto.ReviewStarsInfoResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,8 +14,15 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             value = "SELECT r FROM Review r JOIN FETCH r.member WHERE r.smokingArea.id = :smokingAreaId ORDER BY r.createdAt DESC",
             countQuery = "SELECT COUNT(r) FROM Review r WHERE r.smokingArea.id = :smokingAreaId"
     )
-    Page<Review> findReviewsWithMemberById(@Param("smokingAreaId") Long smokingAreaId, PageRequest pageRequest);
+    Page<Review> findReviewsWithMemberBySmokingAreaId(@Param("smokingAreaId") Long smokingAreaId, PageRequest pageRequest);
 
     @Query("SELECT coalesce(avg(r.score), 0) FROM Review r WHERE r.smokingArea.id = :smokingAreaId")
-    Double findAvgScore(@Param("smokingAreaId") Long smokingAreaId);
+    Double findAvgScoreBySmokingId(@Param("smokingAreaId") Long smokingAreaId);
+
+    @Query("SELECT new com.ssmoker.smoker.domain.review.dto.ReviewStarsInfoResponse(" +
+            "collect(r.score), " +
+            "avg(r.score), " +
+            "count(r.score))" +
+            "FROM Review r WHERE r.smokingArea.id = :smokingAreaId")
+    ReviewStarsInfoResponse findStarsInfoBySmokingAreaId(Long smokingAreaId);
 }

--- a/src/main/java/com/ssmoker/smoker/domain/review/service/ReviewService.java
+++ b/src/main/java/com/ssmoker/smoker/domain/review/service/ReviewService.java
@@ -1,0 +1,47 @@
+package com.ssmoker.smoker.domain.review.service;
+
+import static com.ssmoker.smoker.global.exception.code.ErrorStatus.REVIEW_BAD_REQUEST;
+
+import com.ssmoker.smoker.domain.review.domain.Review;
+import com.ssmoker.smoker.domain.review.exception.ReviewPageNumberException;
+import com.ssmoker.smoker.domain.review.repository.ReviewRepository;
+import com.ssmoker.smoker.domain.review.dto.ReviewResponse;
+import com.ssmoker.smoker.domain.review.dto.ReviewResponses;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+
+    private static final int REVIEW_PAGE_SIZE = 5;
+
+    private final ReviewRepository reviewRepository;
+
+    // 리뷰 폴더로 빼야하나 ?
+    public ReviewResponses getReviewsByAreaId(Long id, int pageNumber) {
+        if (pageNumber < 0) {
+            throw new ReviewPageNumberException(REVIEW_BAD_REQUEST);
+        }
+        Page<Review> reviewPage = reviewRepository.findReviewsWithMemberById(id,
+                PageRequest.of(pageNumber, REVIEW_PAGE_SIZE));
+
+        ReviewResponses reviewResponses = ReviewResponses.of(getReviewResponsesByAreaId(reviewPage), reviewPage.isLast(),
+                reviewPage.getNumber());
+        return reviewResponses;
+    }
+
+    private List<ReviewResponse> getReviewResponsesByAreaId(Page<Review> reviewPage) {
+        return reviewPage.getContent().stream()
+                .map(this::getReviewResponse)
+                .collect(Collectors.toList());
+    }
+
+    private ReviewResponse getReviewResponse(Review review) {
+        return ReviewResponse.of(review, review.getMember().getNickName());
+    }
+}

--- a/src/main/java/com/ssmoker/smoker/domain/review/service/ReviewService.java
+++ b/src/main/java/com/ssmoker/smoker/domain/review/service/ReviewService.java
@@ -3,6 +3,7 @@ package com.ssmoker.smoker.domain.review.service;
 import static com.ssmoker.smoker.global.exception.code.ErrorStatus.REVIEW_BAD_REQUEST;
 
 import com.ssmoker.smoker.domain.review.domain.Review;
+import com.ssmoker.smoker.domain.review.dto.ReviewStarsInfoResponse;
 import com.ssmoker.smoker.domain.review.exception.ReviewPageNumberException;
 import com.ssmoker.smoker.domain.review.repository.ReviewRepository;
 import com.ssmoker.smoker.domain.review.dto.ReviewResponse;
@@ -13,21 +14,22 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true) // 기본적으로 조회 관련 메서드 , READ WRITE 있고 트랜잭션 필요하면 메서드 위에 추가해주세요
 public class ReviewService {
 
     private static final int REVIEW_PAGE_SIZE = 5;
 
     private final ReviewRepository reviewRepository;
 
-    // 리뷰 폴더로 빼야하나 ?
-    public ReviewResponses getReviewsByAreaId(Long id, int pageNumber) {
+    public ReviewResponses getReviewsBySmokingAreaId(Long id, int pageNumber) {
         if (pageNumber < 0) {
             throw new ReviewPageNumberException(REVIEW_BAD_REQUEST);
         }
-        Page<Review> reviewPage = reviewRepository.findReviewsWithMemberById(id,
+        Page<Review> reviewPage = reviewRepository.findReviewsWithMemberBySmokingAreaId(id,
                 PageRequest.of(pageNumber, REVIEW_PAGE_SIZE));
 
         ReviewResponses reviewResponses = ReviewResponses.of(getReviewResponsesByAreaId(reviewPage), reviewPage.isLast(),
@@ -43,5 +45,9 @@ public class ReviewService {
 
     private ReviewResponse getReviewResponse(Review review) {
         return ReviewResponse.of(review, review.getMember().getNickName());
+    }
+
+    public ReviewStarsInfoResponse getStarsInfoBySmokingAreaId(Long smokingAreaId) {
+        return reviewRepository.findStarsInfoBySmokingAreaId(smokingAreaId);
     }
 }

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/controller/SmokingAreaController.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/controller/SmokingAreaController.java
@@ -66,12 +66,4 @@ public class SmokingAreaController {
 
         return ApiResponse.of(SuccessStatus.MAP_LIST_OK, result);
     }
-
-    @Operation(summary = " 총 별점 및 별점 개수 조회",
-    description = "흡연 구역 별 별점 평균 및 전체 별점 조회")
-    @GetMapping("/{smokingAreaId}/stars")
-    public ApiResponse<String> getSmokingAreaStarInfo(@PathVariable Long smokingAreaId){
-
-        return ApiResponse.onSuccess(null);
-    }
 }

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/controller/SmokingAreaController.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/controller/SmokingAreaController.java
@@ -1,15 +1,11 @@
 package com.ssmoker.smoker.domain.smokingArea.controller;
 
 import com.ssmoker.smoker.domain.smokingArea.dto.MapResponse;
-import com.ssmoker.smoker.domain.smokingArea.dto.ReviewResponses;
 import com.ssmoker.smoker.domain.smokingArea.service.SmokingAreaService;
 import com.ssmoker.smoker.domain.smokingArea.dto.SmokingAreaInfoResponse;
 import com.ssmoker.smoker.global.apiPayload.ApiResponse;
 import com.ssmoker.smoker.global.apiPayload.code.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -29,15 +25,6 @@ public class SmokingAreaController {
     @GetMapping("/{smokingAreaId}")
     public ApiResponse<SmokingAreaInfoResponse> getSmokingArea(@PathVariable Long smokingAreaId) {
         SmokingAreaInfoResponse result = smokingAreaService.getSmokingAreaInfo(smokingAreaId);
-
-        return ApiResponse.onSuccess(result);
-    }
-
-    @Operation(summary = "흡연 구역 리뷰 조회(최신순)", description = "쿼리 스트링으로 원하는 페이지를 넘겨주시면 됩니다.")
-    @GetMapping("/{smokingAreaId}/reviews")
-    public ApiResponse<ReviewResponses> getReviews(@PathVariable Long smokingAreaId,
-                                                   @RequestParam @Min(0) @NotNull Integer pageNumber) {
-        ReviewResponses result = smokingAreaService.getReviewsByAreaId(smokingAreaId, pageNumber);
 
         return ApiResponse.onSuccess(result);
     }
@@ -78,5 +65,13 @@ public class SmokingAreaController {
                 = smokingAreaService.getSmokingAreaListResponse(userLat, userLng, filter);
 
         return ApiResponse.of(SuccessStatus.MAP_LIST_OK, result);
+    }
+
+    @Operation(summary = " 총 별점 및 별점 개수 조회",
+    description = "흡연 구역 별 별점 평균 및 전체 별점 조회")
+    @GetMapping("/{smokingAreaId}/stars")
+    public ApiResponse<String> getSmokingAreaStarInfo(@PathVariable Long smokingAreaId){
+
+        return ApiResponse.onSuccess(null);
     }
 }

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/domain/SmokingArea.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/domain/SmokingArea.java
@@ -39,8 +39,6 @@ public class SmokingArea extends BaseEntity {
     private Feature feature;
 
     private String imageUrl;
-    /*@Column(nullable = false)
-    private Boolean isApproved;*/
 
     @OneToMany(mappedBy = "smokingArea", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Review> reviews = new ArrayList<>();

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/dto/SmokingAreaStarInfoResponse.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/dto/SmokingAreaStarInfoResponse.java
@@ -1,0 +1,4 @@
+package com.ssmoker.smoker.domain.smokingArea.dto;
+
+public class SmokingAreaStarInfoResponse {
+}

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/repository/SmokingAreaRepository.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/repository/SmokingAreaRepository.java
@@ -20,7 +20,7 @@ public interface SmokingAreaRepository extends JpaRepository<SmokingArea, Long> 
             "where s.id = :smokingAreaId")
     int findReviewCountBySmokingAreaId(@Param("smokingAreaId") Long smokingAreaId);
 
-    //null이 아닌 0을 반환하도록 함
+    //null 이 아닌 0을 반환하도록 함
     @Query("select coalesce(count(sa), 0)" +
             "from SmokingArea s left join SavedSmokingArea sa " +
             "on sa.smokingArea.id = s.id " +

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/service/SmokingAreaService.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/service/SmokingAreaService.java
@@ -29,8 +29,6 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class SmokingAreaService {
 
-    private static final int REVIEW_PAGE_SIZE = 5;
-
     private final SmokingAreaRepository smokingAreaRepository;
     private final ReviewRepository reviewRepository;
 
@@ -42,27 +40,6 @@ public class SmokingAreaService {
         throw new SmokingAreaNotFoundException(SMOKING_AREA_NOT_FOUND);
     }
 
-    public ReviewResponses getReviewsByAreaId(Long id, int pageNumber) {
-        if (pageNumber < 0) {
-            throw new ReviewPageNumberException(REVIEW_BAD_REQUEST);
-        }
-        Page<Review> reviewPage = reviewRepository.findReviewsWithMemberById(id,
-                PageRequest.of(pageNumber, REVIEW_PAGE_SIZE));
-
-        ReviewResponses reviewResponses = ReviewResponses.of(getReviewResponsesByAreaId(reviewPage), reviewPage.isLast(),
-                reviewPage.getNumber());
-        return reviewResponses;
-    }
-
-    private List<ReviewResponse> getReviewResponsesByAreaId(Page<Review> reviewPage) {
-        return reviewPage.getContent().stream()
-                .map(this::getReviewResponse)
-                .collect(Collectors.toList());
-    }
-
-    private ReviewResponse getReviewResponse(Review review) {
-        return ReviewResponse.of(review, review.getMember().getNickName());
-    }
 
     //marker를 위한 모든 db 보내기
     public MapResponse.SmokingMarkersResponse getSmokingMarkersResponse() {

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/service/SmokingAreaService.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/service/SmokingAreaService.java
@@ -1,28 +1,20 @@
 package com.ssmoker.smoker.domain.smokingArea.service;
 
-import static com.ssmoker.smoker.global.exception.code.ErrorStatus.REVIEW_BAD_REQUEST;
 import static com.ssmoker.smoker.global.exception.code.ErrorStatus.SMOKING_AREA_NOT_FOUND;
-import static com.ssmoker.smoker.global.exception.code.ErrorStatus._BAD_REQUEST;
 
-import com.ssmoker.smoker.domain.review.domain.Review;
-import com.ssmoker.smoker.domain.review.exception.ReviewPageNumberException;
 import com.ssmoker.smoker.domain.review.repository.ReviewRepository;
 import com.ssmoker.smoker.domain.smokingArea.domain.SmokingArea;
 import com.ssmoker.smoker.domain.smokingArea.dto.*;
 import com.ssmoker.smoker.domain.smokingArea.exception.SmokingAreaNotFoundException;
 import com.ssmoker.smoker.domain.smokingArea.repository.SmokingAreaRepository;
-import com.ssmoker.smoker.global.apiPayload.ApiResponse;
 import com.ssmoker.smoker.global.exception.SmokerBadRequestException;
 import com.ssmoker.smoker.global.exception.code.ErrorStatus;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -139,7 +131,7 @@ public class SmokingAreaService {
             int savedCount = smokingAreaRepository.findSavedCountBySmokingAreaId(
                     smokingArea.getId());
 
-            Double avgRating = reviewRepository.findAvgScore(smokingArea.getId());
+            Double avgRating = reviewRepository.findAvgScoreBySmokingId(smokingArea.getId());
 
             return new MapResponse.SmokingAreaInfoWithDistance(smokingArea.getId(),
                     smokingArea.getSmokingAreaName(),

--- a/src/main/java/com/ssmoker/smoker/global/configuration/SecurityConfig.java
+++ b/src/main/java/com/ssmoker/smoker/global/configuration/SecurityConfig.java
@@ -21,23 +21,20 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+    /**
+     * 가독성을 위해 api 요청중에서 로그인이 필요없는 것 url 많은 api 들은 일단 전부 허용되게 처리해뒀고(/**)
+     * 해당 api 에서 로그인이 필요한 것이 있으면 configureAuthorization 에 해당 url 추가하시면 됩니다.
+     */
+    private static final String ALLOW_REVIEW_URL = "/api/reviews/**";
+    private static final String ALLOW_SMOKING_AREA_URL = "/api/smoking-area/**";
+    private static final String ALLOW_AUTH_URL = "/api/auth/**";
 
-    private final JwtRequestFilter jwtRequestFilter;
-
-    private static final String[] SECURITY_ALLOW_ARRAY  = { //인증 없이 접근 가능한 엔드 포인트
-            "/api/auth/login/google", //구글 로그인
-            "/api/auth/login/kakao", //카카오 로그인
-            "/api/auth/refresh", //토큰 재발급
+    private static final String[] SECURITY_ALLOW_ARRAY = { //인증 없이 접근 가능한 엔드 포인트
+            ALLOW_AUTH_URL,
+            ALLOW_SMOKING_AREA_URL,
+            ALLOW_REVIEW_URL,
             "/api/member/notices", //공지사항
-            "/api/smoking-area/{smokingAreaId}", //흡연 구역 상세 정보 조회
-            "/api/smoking-area/{smokingAreaId}/reviews", // 흡연 구역 리뷰 조회
-            "/api/updated_history/{smokingAreaId}", // 업데이트 히스토리 조회
-            "/api/smoking-area/{smokingAreaId}/rating_info", //총 별점 & 별점 개수 조회
-            "/api/smoking-area", //흡연구역 마커 보이기
-            "/api/smoking-area/{smokingAreaId}/simple", //흡연 구역 지도 마커 클릭했을 때 흡연 구역 정보 조회 (모달)
-            "/api/smoking-area/list", //흡연구역 목록보기
-            "/api/smoking-area/search", //흡연 구역 검색
-            "/test/{status}", //테스트 컨트롤러
+            "/test/**",
             //등등 추가 및 수정해주세요
             "/health",
             "/error",
@@ -55,6 +52,8 @@ public class SecurityConfig {
             "/api/recommend/**",
             "/favicon.ico"
     };
+
+    private final JwtRequestFilter jwtRequestFilter;
 
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {
@@ -101,7 +100,8 @@ public class SecurityConfig {
             response.setStatus(HttpServletResponse.SC_FORBIDDEN);
             response.setContentType("application/json");
             response.setCharacterEncoding("UTF-8");
-            response.getWriter().write("{ \"error\": \"Access Denied\", \"message\": \"권한이 없습니다.\", \"path\": \"" + request.getRequestURI() + "\" }");
+            response.getWriter().write("{ \"error\": \"Access Denied\", \"message\": \"권한이 없습니다.\", \"path\": \""
+                    + request.getRequestURI() + "\" }");
         };
     }
 

--- a/src/main/java/com/ssmoker/smoker/global/exception/ExceptionAdvice.java
+++ b/src/main/java/com/ssmoker/smoker/global/exception/ExceptionAdvice.java
@@ -44,7 +44,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
         e.getBindingResult().getFieldErrors().stream()
                 .forEach(fieldError -> {
-                    String fieldName = fieldError.getField();
+                    String fieldName =  fieldError.getField();
                     String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
                     errors.merge(fieldName, errorMessage,
                             (existingErrorMessage, newErrorMessage) -> existingErrorMessage + ", " + newErrorMessage);

--- a/src/main/java/com/ssmoker/smoker/global/security/filter/JwtRequestFilter.java
+++ b/src/main/java/com/ssmoker/smoker/global/security/filter/JwtRequestFilter.java
@@ -96,6 +96,9 @@ public class JwtRequestFilter extends OncePerRequestFilter {
                 || path.startsWith("/api/smoking-area/{smokingAreaId}/simple")
                 || path.startsWith("/api/smoking-area/list")
                 || path.startsWith("/api/smoking-area/search")
+
+                //Review
+                || path.startsWith("/api/reviews")
                 // 필요하다면 다른 permitAll 경로들도 추가
                 // ...
                 ;

--- a/src/main/java/com/ssmoker/smoker/test/TestController.java
+++ b/src/main/java/com/ssmoker/smoker/test/TestController.java
@@ -24,6 +24,11 @@ public class TestController {
     private final AmazonS3Manager amazonS3Manager;
     private final TestRepository testRepository;
 
+    @GetMapping("/test/sqlException/{testId}")
+    public ApiResponse<Integer> testSqlException(@PathVariable Integer testId) {
+        return ApiResponse.onSuccess(testRepository.testQuery(testId));
+    }
+
     @GetMapping("/test/{status}")
     public ApiResponse<String> test(@PathVariable String status) {
         if (status.equals("error")) {

--- a/src/main/java/com/ssmoker/smoker/test/TestRepository.java
+++ b/src/main/java/com/ssmoker/smoker/test/TestRepository.java
@@ -1,6 +1,10 @@
 package com.ssmoker.smoker.test;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface TestRepository extends JpaRepository<Test, Long> {
+    @Query("select count(*) from Test where id = :id")
+    int testQuery(int id);
 }


### PR DESCRIPTION
## 작업 내용

> 상세 페이지 - 별점 평균, 개수 , 별점 별 개수 조회 api 구현한다. 

## 참고 사항

> reviewRepository에만 의존하던 api를 review 디렉토리로 옮기고 url 경로도 smoking-area에서 reviews로 변경했습니다. 
securityConfig에서 url 추가하는 부분을 변경했습니다. (변경 내용은 주석 달아뒀습니다 ~~)

## 연관 이슈

> close #38 


<br>