### PR TITLE
[Refactor] generateProfileKeyName 추가, 프로필 이미지 업로드 경로 수정

### DIFF
--- a/src/main/java/com/ssmoker/smoker/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/ssmoker/smoker/domain/member/service/MemberServiceImpl.java
@@ -55,7 +55,7 @@ public class MemberServiceImpl implements MemberService {
         Member member = memberRepository.findById(memberId).orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
         try{
             final String uuid = UUID.randomUUID().toString();
-            final String keyName = amazonS3Manager.generateReviewKeyName(uuid);
+            final String keyName = amazonS3Manager.generateProfileKeyName(uuid);
             final String imageUrl = amazonS3Manager.uploadFile(keyName, request.getMultipartFile());
             member.setProfileImageUrl(imageUrl);
             memberRepository.save(member);

--- a/src/main/java/com/ssmoker/smoker/global/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/com/ssmoker/smoker/global/aws/s3/AmazonS3Manager.java
@@ -33,6 +33,10 @@ public class AmazonS3Manager {
     public String generateReviewKeyName(String uuid) {
         return amazonConfig.getReviewPath() + '/'  + uuid;
     }
+    // 프로필 사진 저장은 해당 url 을 사용하여 저장
+    public String generateProfileKeyName(String uuid) {
+        return amazonConfig.getProfilePath() + '/'  + uuid;
+    }
     // 흡연 구역 사진 저장은 해당 url 을 사용하여 저장
     public String generateSmokingAreaKeyName(String keyName, String uuid) {
         return amazonConfig.getSmokingAreaPath() + '/' + keyName + uuid;

--- a/src/main/java/com/ssmoker/smoker/global/configuration/AmazonConfig.java
+++ b/src/main/java/com/ssmoker/smoker/global/configuration/AmazonConfig.java
@@ -34,6 +34,9 @@ public class AmazonConfig {
     @Value("${cloud.aws.s3.path.review}")
     private String reviewPath;
 
+    @Value("${cloud.aws.s3.path.profile}")
+    private String profilePath;
+
     @Value("${cloud.aws.s3.path.smokingArea}")
     private String smokingAreaPath;
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,6 +45,7 @@ cloud:
       path:
         review: review
         smokingArea: area
+        profile : profile
     credentials:
       access-key: ${AWS_ACCESS_KEY}
       secret-key: ${AWS_SECRET_KEY}


### PR DESCRIPTION
## 작업 내용

> generateProfileKeyName 추가, 프로필 이미지 업로드 경로 /profile로 수정

## 참고 사항

> generateProfileKeyName 메서드가 추가되었습니다
> 프로필 이미지가 S3의 profile 폴더에 업로드 되도록 수정했습니다

## 연관 이슈

>  close #42 


<br>