### PR TITLE
[Feat] 나의 업데이트 히스토리 조회 API 추가

### DIFF
--- a/src/main/java/com/ssmoker/smoker/domain/member/controller/MemberController.java
+++ b/src/main/java/com/ssmoker/smoker/domain/member/controller/MemberController.java
@@ -47,4 +47,11 @@ public class MemberController {
         MemberResponseDTO.MemberReviewListDTO result = memberService.viewMemberReviews(memberId,pageNumber);
         return ApiResponse.of(SuccessStatus.PROFILE_REVIEWS_OK,result);
     }
+
+    @Operation(summary = "마이페이지 나의 업데이트 히스토리 조회 API", description = "마이페이지 상세탭 나의 업데이트 히스토리를 5개씩 조회합니다. 쿼리스트링으로 pageNumber를 넘겨주세요. 1부터 시작됩니다.")
+    @GetMapping(value = "/update")
+    public ApiResponse<MemberResponseDTO.MemberUpdateListDTO> getMemberUpdate(@AuthUser Long memberId, @RequestParam("pageNumber") @Min(0) @NotNull Integer pageNumber) {
+        MemberResponseDTO.MemberUpdateListDTO result = memberService.viewMemberUpdateHistory(memberId,pageNumber);
+        return ApiResponse.of(SuccessStatus.PROFILE_UPDATE_OK,result);
+    }
 }

--- a/src/main/java/com/ssmoker/smoker/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/ssmoker/smoker/domain/member/converter/MemberConverter.java
@@ -2,6 +2,8 @@ package com.ssmoker.smoker.domain.member.converter;
 
 import com.ssmoker.smoker.domain.member.dto.MemberResponseDTO;
 import com.ssmoker.smoker.domain.review.domain.Review;
+import com.ssmoker.smoker.domain.updatedHistory.domain.Action;
+import com.ssmoker.smoker.domain.updatedHistory.domain.UpdatedHistory;
 import org.springframework.data.domain.Page;
 
 import java.util.Collections;
@@ -31,4 +33,37 @@ public class MemberConverter {
                 .totalPage(reviews.getTotalPages())
                 .build();
     }
+
+    public static MemberResponseDTO.MemberUpdateDTO toMemberUpdateDTO(UpdatedHistory updatedHistory) {
+        String content = updatedHistory.getUpdateCount().toString();
+
+        Action action = updatedHistory.getAction();
+        switch (action) {
+            case UPDATE:
+                content += "번째 수정에 참여했어요!";
+                break;
+            case REGISTRATION:
+                content = "장소를 등록했어요!";
+                break;
+        }
+        return MemberResponseDTO.MemberUpdateDTO.builder()
+                .updateHistoryId(updatedHistory.getId())
+                .smokingAreaName(updatedHistory.getSmokingArea().getSmokingAreaName())
+                .createdAt(updatedHistory.getCreatedAt())
+                .content(content)
+                .build();
+    }
+
+    public static MemberResponseDTO.MemberUpdateListDTO toMemberUpdateListDTO(Page<UpdatedHistory> updatedHistories) {
+        List<MemberResponseDTO.MemberUpdateDTO> memberUpdateDTOList = updatedHistories.stream()
+                .map(MemberConverter::toMemberUpdateDTO).collect(Collectors.toList());
+
+        Collections.reverse(memberUpdateDTOList);
+
+        return MemberResponseDTO.MemberUpdateListDTO.builder()
+                .MemberUpdateList(memberUpdateDTOList)
+                .totalPage(updatedHistories.getTotalPages())
+                .build();
+    }
+
 }

--- a/src/main/java/com/ssmoker/smoker/domain/member/converter/MemberConverter.java
+++ b/src/main/java/com/ssmoker/smoker/domain/member/converter/MemberConverter.java
@@ -4,6 +4,7 @@ import com.ssmoker.smoker.domain.member.dto.MemberResponseDTO;
 import com.ssmoker.smoker.domain.review.domain.Review;
 import org.springframework.data.domain.Page;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -24,7 +25,7 @@ public class MemberConverter {
     public static MemberResponseDTO.MemberReviewListDTO toMemberReviewListDTO(Page<Review> reviews) {
         List<MemberResponseDTO.MemberReviewDTO> memberReviewDTOList = reviews.stream()
                 .map(MemberConverter::toMemberReviewDTO).collect(Collectors.toList());
-
+        Collections.reverse(memberReviewDTOList);
         return MemberResponseDTO.MemberReviewListDTO.builder()
                 .MemberReviewList(memberReviewDTOList)
                 .totalPage(reviews.getTotalPages())

--- a/src/main/java/com/ssmoker/smoker/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/ssmoker/smoker/domain/member/dto/MemberResponseDTO.java
@@ -34,4 +34,20 @@ public class MemberResponseDTO {
         private List<MemberReviewDTO> MemberReviewList;
         private Integer totalPage;
     }
+
+    @Builder
+    @Getter
+    public static class MemberUpdateDTO{
+        private Long updateHistoryId;
+        private String smokingAreaName;
+        private LocalDateTime createdAt;
+        private String content;
+    }
+
+    @Builder
+    @Getter
+    public static class MemberUpdateListDTO{
+        private List<MemberUpdateDTO> MemberUpdateList;
+        private Integer totalPage;
+    }
 }

--- a/src/main/java/com/ssmoker/smoker/domain/member/service/MemberService.java
+++ b/src/main/java/com/ssmoker/smoker/domain/member/service/MemberService.java
@@ -11,4 +11,5 @@ public interface MemberService {
     String updateProfileImage(Long memberId, MemberRequestDTO.updateProfileImageRequestDTO request);
     MemberResponseDTO.MemberProfileDTO viewProfile(Long memberId);
     MemberResponseDTO.MemberReviewListDTO viewMemberReviews(Long memberId, Integer page);
+    MemberResponseDTO.MemberUpdateListDTO viewMemberUpdateHistory(Long memberId, Integer page);
 }

--- a/src/main/java/com/ssmoker/smoker/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/ssmoker/smoker/domain/member/service/MemberServiceImpl.java
@@ -7,6 +7,8 @@ import com.ssmoker.smoker.domain.member.dto.MemberResponseDTO;
 import com.ssmoker.smoker.domain.member.repository.MemberRepository;
 import com.ssmoker.smoker.domain.review.domain.Review;
 import com.ssmoker.smoker.domain.review.repository.ReviewRepository;
+import com.ssmoker.smoker.domain.updatedHistory.domain.UpdatedHistory;
+import com.ssmoker.smoker.domain.updatedHistory.repository.UpdatedHistoryRepository;
 import com.ssmoker.smoker.global.aws.s3.AmazonS3Manager;
 import com.ssmoker.smoker.global.exception.GeneralException;
 import com.ssmoker.smoker.global.exception.SmokerBadRequestException;
@@ -30,6 +32,7 @@ public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
     private final ReviewRepository reviewRepository;
+    private final UpdatedHistoryRepository updatedHistoryRepository;
     private final AmazonS3Manager amazonS3Manager;
 
     @Override
@@ -89,5 +92,17 @@ public class MemberServiceImpl implements MemberService {
         MemberResponseDTO.MemberReviewListDTO memberReviewList = MemberConverter.toMemberReviewListDTO(reviewPage);
 
         return memberReviewList;
+    }
+
+    @Override
+    @Transactional
+    public MemberResponseDTO.MemberUpdateListDTO viewMemberUpdateHistory(Long memberId, Integer page) {
+        Member member = memberRepository.findById(memberId).orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        PageRequest pageRequest = PageRequest.of(page - 1, 5);
+
+        Page<UpdatedHistory> updatedHistoryPage = updatedHistoryRepository.findAllByMember(pageRequest,member);
+        MemberResponseDTO.MemberUpdateListDTO memberUpdateList = MemberConverter.toMemberUpdateListDTO(updatedHistoryPage);
+
+        return memberUpdateList;
     }
 }

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/controller/SmokingAreaController.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/controller/SmokingAreaController.java
@@ -29,7 +29,7 @@ public class SmokingAreaController {
    //지도 api
     @Operation(summary = "흡연 구역 지도_마커표시 위함",
     description = "프론트가 지도에 마커표시를 할 수 있도록 흡연구역 db를 보내주는 역할")
-    @GetMapping
+    @GetMapping("/marker")
     public ApiResponse<MapResponse.SmokingMarkersResponse> getSmokingAreaMakersInfo(){
         MapResponse.SmokingMarkersResponse markers = smokingAreaService.getSmokingMarkersResponse();
 

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/service/SmokingAreaService.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/service/SmokingAreaService.java
@@ -10,6 +10,7 @@ import com.ssmoker.smoker.domain.smokingArea.domain.SmokingArea;
 import com.ssmoker.smoker.domain.smokingArea.dto.*;
 import com.ssmoker.smoker.domain.smokingArea.exception.SmokingAreaNotFoundException;
 import com.ssmoker.smoker.domain.smokingArea.repository.SmokingAreaRepository;
+import com.ssmoker.smoker.domain.updatedHistory.domain.Action;
 import com.ssmoker.smoker.domain.updatedHistory.domain.UpdatedHistory;
 import com.ssmoker.smoker.domain.updatedHistory.repository.UpdatedHistoryRepository;
 import com.ssmoker.smoker.global.exception.SmokerBadRequestException;
@@ -191,7 +192,10 @@ public class SmokingAreaService {
         member.setUpdateCount(member.getUpdateCount() + 1);
         memberRepository.save(member);
 
-        UpdatedHistory history = new UpdatedHistory(member, smokingArea);
+        int updateCount = updatedHistoryRepository.countBySmokingAreaId(smokingAreaId)+1;
+        Action action = Action.UPDATE;
+
+        UpdatedHistory history = new UpdatedHistory(updateCount,action,member, smokingArea);
         updatedHistoryRepository.save(history);
 
         return SmokingAreaUpdateRequest.of(smokingArea);

--- a/src/main/java/com/ssmoker/smoker/domain/updatedHistory/domain/Action.java
+++ b/src/main/java/com/ssmoker/smoker/domain/updatedHistory/domain/Action.java
@@ -1,0 +1,5 @@
+package com.ssmoker.smoker.domain.updatedHistory.domain;
+
+public enum Action {
+    UPDATE,REGISTRATION
+}

--- a/src/main/java/com/ssmoker/smoker/domain/updatedHistory/domain/UpdatedHistory.java
+++ b/src/main/java/com/ssmoker/smoker/domain/updatedHistory/domain/UpdatedHistory.java
@@ -16,9 +16,11 @@ public class UpdatedHistory extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Integer updateCount;
+    @Column(nullable = false)
+    private Integer updateCount=0;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private Action action;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/ssmoker/smoker/domain/updatedHistory/domain/UpdatedHistory.java
+++ b/src/main/java/com/ssmoker/smoker/domain/updatedHistory/domain/UpdatedHistory.java
@@ -16,6 +16,11 @@ public class UpdatedHistory extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    private Integer updateCount;
+
+    @Enumerated(EnumType.STRING)
+    private Action action;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
@@ -24,7 +29,9 @@ public class UpdatedHistory extends BaseEntity {
     @JoinColumn(name = "smoking_area_id", nullable = false)
     private SmokingArea smokingArea;
 
-    public UpdatedHistory(Member member, SmokingArea smokingArea) {
+    public UpdatedHistory(Integer updateCount, Action action, Member member, SmokingArea smokingArea) {
+        this.updateCount = updateCount;
+        this.action = action;
         this.member = member;
         this.smokingArea = smokingArea;
     }

--- a/src/main/java/com/ssmoker/smoker/domain/updatedHistory/repository/UpdatedHistoryRepository.java
+++ b/src/main/java/com/ssmoker/smoker/domain/updatedHistory/repository/UpdatedHistoryRepository.java
@@ -1,5 +1,6 @@
 package com.ssmoker.smoker.domain.updatedHistory.repository;
 
+import com.ssmoker.smoker.domain.member.domain.Member;
 import com.ssmoker.smoker.domain.updatedHistory.domain.UpdatedHistory;
 import com.ssmoker.smoker.domain.updatedHistory.dto.UpdatedHistoryResponse;
 import org.springframework.data.domain.Page;
@@ -30,5 +31,7 @@ public interface UpdatedHistoryRepository extends JpaRepository<UpdatedHistory, 
 
     @Query("SELECT COUNT(uh) FROM UpdatedHistory uh WHERE uh.smokingArea.id = :smokingAreaId")
     int countBySmokingAreaId(@Param("smokingAreaId") Long smokingAreaId);
+
+    Page<UpdatedHistory> findAllByMember(PageRequest pageRequest, Member member);
 
 }

--- a/src/main/java/com/ssmoker/smoker/global/apiPayload/code/SuccessStatus.java
+++ b/src/main/java/com/ssmoker/smoker/global/apiPayload/code/SuccessStatus.java
@@ -27,7 +27,8 @@ public enum SuccessStatus implements BaseCode {
     NICKNAME_OK(HttpStatus.OK, "PROFILE2001", "닉네임 변경이 완료되었습니다."),
     PROFILE_IMAGE_OK(HttpStatus.OK, "PROFILE2002", "프로필 이미지 변경이 완료되었습니다."),
     PROFILE_OK(HttpStatus.OK, "PROFILE2003", "프로필 조회 성공"),
-    PROFILE_REVIEWS_OK(HttpStatus.OK, "PROFILE2004", "내가 쓴 리뷰 조회 성공")
+    PROFILE_REVIEWS_OK(HttpStatus.OK, "PROFILE2004", "내가 쓴 리뷰 조회 성공"),
+    PROFILE_UPDATE_OK(HttpStatus.OK, "PROFILE2005", "나의 업데이트 히스토리 조회 성공")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/ssmoker/smoker/global/security/filter/JwtRequestFilter.java
+++ b/src/main/java/com/ssmoker/smoker/global/security/filter/JwtRequestFilter.java
@@ -92,7 +92,6 @@ public class JwtRequestFilter extends OncePerRequestFilter {
                 || path.startsWith("/test")
 
                 //smokingArea
-                || path.startsWith("/api/smoking-area")
                 || path.startsWith("/api/smoking-area/{smokingAreaId}/simple")
                 || path.startsWith("/api/smoking-area/list")
                 || path.startsWith("/api/smoking-area/search")


### PR DESCRIPTION
## 작업 내용

> 마이페이지 상세탭 나의 업데이트 히스토리 조회 API 추가
> UpdatedHistory 엔티티 수정

## 참고 사항
> 1.마이페이지 상세탭 나의 업데이트 히스토리 조회 API가 추가되었습니다
> 2.UpdatedHistory 엔티티가 수정 되었습니다
> - Action (행위 / UPDATE,REGISTRATION), updateCount (해당 흡구의 몇 번째 업데이트인지) 칼럼이 추가되었습니다
> - 위 이유로 흡구 정보 업데이트 로직에 UpdatedHistory 생성시 Action과 updateCount 정보를 저장하도록 수정되었습니다
## 연관 이슈

> close #48 


<br>