### PR TITLE
[Fix] 흡연 구역 컬럼에 시설 형태를 추가하고, 정보 컬럼에 데이터를 추가한다. 

### DIFF
--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/controller/SmokingAreaController.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/controller/SmokingAreaController.java
@@ -29,38 +29,38 @@ public class SmokingAreaController {
         return ApiResponse.onSuccess(result);
     }
 
-   //지도 api
+    //지도 api
     @Operation(summary = "흡연 구역 지도_마커표시 위함",
-    description = "프론트가 지도에 마커표시를 할 수 있도록 흡연구역 db를 보내주는 역할")
+            description = "프론트가 지도에 마커표시를 할 수 있도록 흡연구역 db를 보내주는 역할")
     @GetMapping("/marker")
-    public ApiResponse<MapResponse.SmokingMarkersResponse> getSmokingAreaMakersInfo(){
+    public ApiResponse<MapResponse.SmokingMarkersResponse> getSmokingAreaMakersInfo() {
         MapResponse.SmokingMarkersResponse markers = smokingAreaService.getSmokingMarkersResponse();
 
         return ApiResponse.of(SuccessStatus.MAP_INFO_OK, markers);
     }
 
     @Operation(summary = "흡연 구역 마커 클릭(모달)",
-    description = "흡연구역 마커 클릭 시 다른 작은 창으로 마커 정보 알려주는 역할")
+            description = "흡연구역 마커 클릭 시 다른 작은 창으로 마커 정보 알려주는 역할")
     @GetMapping("/{smokingAreaId}/simple")
     public ApiResponse<MapResponse.MarkerResponse> getSmokingAreaMarker(
             @PathVariable(name = "smokingAreaId") Long smokingAreaId,
             @RequestParam(name = "userLat") Double userLat,
             @RequestParam(name = "userLng") Double userLng
-    ){
+    ) {
         MapResponse.MarkerResponse marker = smokingAreaService.getMarkerResponse(
                 smokingAreaId, userLat, userLng);
 
-        return ApiResponse.of(SuccessStatus.MAP_MARKER_OK,marker);
+        return ApiResponse.of(SuccessStatus.MAP_MARKER_OK, marker);
     }
 
     @Operation(summary = "흡연 구역 목록",
-    description = "사용자 현재 위치에서 1km 반경 내에 있는 흡연 구역 목록 조회")
+            description = "사용자 현재 위치에서 1km 반경 내에 있는 흡연 구역 목록 조회")
     @GetMapping("/list")
     public ApiResponse<MapResponse.SmokingAreaListResponse> getSmokingAreaList(
             @RequestParam(name = "userLat") Double userLat,
             @RequestParam(name = "userLng") Double userLng,
             @RequestParam(name = "filter") String filter
-    ){
+    ) {
         MapResponse.SmokingAreaListResponse result
                 = smokingAreaService.getSmokingAreaListResponse(userLat, userLng, filter);
 
@@ -68,10 +68,10 @@ public class SmokingAreaController {
     }
 
     @Operation(summary = "흡연 구역 검색 목록",
-    description = "검색어와 현재 유저의 위치를 request로 받고 흡연 구역 목록 조회")
+            description = "검색어와 현재 유저의 위치를 request로 받고 흡연 구역 목록 조회")
     @PostMapping("/search")
     public ApiResponse<MapResponse.SmokingAreaListResponse> getSearchAreaList(
-            @RequestBody SmokingAreaRequest.SearchRequest request){
+            @RequestBody SmokingAreaRequest.SearchRequest request) {
         MapResponse.SmokingAreaListResponse result
                 = smokingAreaService.getSearchingAreaListResponse(request);
 

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/domain/Feature.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/domain/Feature.java
@@ -35,4 +35,15 @@ public class Feature {
     @Column(nullable = false)
     private Boolean isOutdoor; // 야외에 있어요
 
+    public Feature update(Feature updatedFeature) {
+        return new Feature(
+                updatedFeature.hasVentilationSystem,
+                updatedFeature.isClean,
+                updatedFeature.hasTrashBin,
+                updatedFeature.hasChair,
+                updatedFeature.isAccessible,
+                updatedFeature.hasAirConditioning,
+                updatedFeature.isOutdoor
+        );
+    }
 }

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/domain/Feature.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/domain/Feature.java
@@ -5,45 +5,74 @@ import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Embeddable
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-@Setter
 public class Feature {
 
     @Column(nullable = false)
-    private Boolean hasVentilationSystem; // 환풍 시설이 있어요
+    private Boolean hasAirPurifier; // 공기 청정 기능
 
     @Column(nullable = false)
-    private Boolean isClean; // 깔끔해요
+    private Boolean hasAirConditioning; // 냉난방 기능
 
     @Column(nullable = false)
-    private Boolean hasTrashBin; // 쓰레기통이 있어요
+    private Boolean hasChair; // 의자 제공
 
     @Column(nullable = false)
-    private Boolean hasChair; // 의자가 있어요
+    private Boolean hasTrashBin; // 쓰레기통
 
     @Column(nullable = false)
-    private Boolean isAccessible; // 장애인 편의시설이에요
+    private Boolean hasVentilationSystem; // 환기 시스템
 
     @Column(nullable = false)
-    private Boolean hasAirConditioning; // 냉난방이 가능해요
+    private Boolean isAccessible; // 휠체어 진입 가능 여부
 
     @Column(nullable = false)
-    private Boolean isOutdoor; // 야외에 있어요
+    private Boolean hasCCTV; // CCTV 설치 여부
 
+    @Column(nullable = false)
+    private Boolean hasEmergencyButton; // 비상 버튼
+
+    @Column(nullable = false)
+    private Boolean hasVoiceGuidance; // 음성 안내 시스템
+
+    @Column(nullable = false)
+    private Boolean hasFireExtinguisher; // 소화기 비치 여부
+
+    @Column(nullable = false)
+    private Boolean isRegularlyCleaned; // 정기적인 청소 여부
+
+    @Column(nullable = false)
+    private Boolean hasCigaretteDisposal; // 담배꽁초 처리함 제공 여부
+
+    @Column(nullable = false)
+    private Boolean hasSunshade; // 햇빛 차단 시설
+
+    @Column(nullable = false)
+    private Boolean hasRainProtection; // 비바람 차단 시설
+
+    /**
+     * Feature 업데이트 메서드 (불변성을 유지하면서 새로운 객체 생성)
+     */
     public Feature update(Feature updatedFeature) {
         return new Feature(
-                updatedFeature.hasVentilationSystem,
-                updatedFeature.isClean,
-                updatedFeature.hasTrashBin,
-                updatedFeature.hasChair,
-                updatedFeature.isAccessible,
+                updatedFeature.hasAirPurifier,
                 updatedFeature.hasAirConditioning,
-                updatedFeature.isOutdoor
+                updatedFeature.hasChair,
+                updatedFeature.hasTrashBin,
+                updatedFeature.hasVentilationSystem,
+                updatedFeature.isAccessible,
+                updatedFeature.hasCCTV,
+                updatedFeature.hasEmergencyButton,
+                updatedFeature.hasVoiceGuidance,
+                updatedFeature.hasFireExtinguisher,
+                updatedFeature.isRegularlyCleaned,
+                updatedFeature.hasCigaretteDisposal,
+                updatedFeature.hasSunshade,
+                updatedFeature.hasRainProtection
         );
     }
 }

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/domain/Feature.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/domain/Feature.java
@@ -13,16 +13,26 @@ import lombok.Setter;
 @Getter
 @Setter
 public class Feature {
-    @Column(nullable = false)
-    private Boolean isEnclosedSmokingArea;
 
     @Column(nullable = false)
-    private Boolean hasChair;
+    private Boolean hasVentilationSystem; // 환풍 시설이 있어요
 
     @Column(nullable = false)
-    private Boolean hasTrashBin;
+    private Boolean isClean; // 깔끔해요
 
     @Column(nullable = false)
-    private Boolean hasAirConditioning;
+    private Boolean hasTrashBin; // 쓰레기통이 있어요
+
+    @Column(nullable = false)
+    private Boolean hasChair; // 의자가 있어요
+
+    @Column(nullable = false)
+    private Boolean isAccessible; // 장애인 편의시설이에요
+
+    @Column(nullable = false)
+    private Boolean hasAirConditioning; // 냉난방이 가능해요
+
+    @Column(nullable = false)
+    private Boolean isOutdoor; // 야외에 있어요
 
 }

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/domain/SmokingArea.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/domain/SmokingArea.java
@@ -51,4 +51,8 @@ public class SmokingArea extends BaseEntity {
 
     @OneToMany(mappedBy = "smokingArea", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SavedSmokingArea> savedSmokingAreas = new ArrayList<>();
+
+    public void updateFeature(Feature updatedFeature) {
+        this.feature = this.feature.update(updatedFeature);
+    }
 }

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/domain/SmokingArea.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/domain/SmokingArea.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -38,6 +39,9 @@ public class SmokingArea extends BaseEntity {
     private Feature feature;
 
     private String imageUrl;
+
+    @NotNull
+    private String areaType;
 
     @OneToMany(mappedBy = "smokingArea", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Review> reviews = new ArrayList<>();

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/dto/SmokingAreaDetailResponse.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/dto/SmokingAreaDetailResponse.java
@@ -1,5 +1,6 @@
 package com.ssmoker.smoker.domain.smokingArea.dto;
 
+import com.ssmoker.smoker.domain.smokingArea.domain.Feature;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,8 +13,6 @@ public class SmokingAreaDetailResponse {
     private String smokingAreaName;
     private String address;
     private String imageUrl;
-    private Boolean hasAirConditioning;
-    private Boolean hasChair;
-    private Boolean hasTrashBin;
-    private Boolean isEnclosedSmokingArea;
+    private String areaType;
+    private Feature feature;
 }

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/dto/SmokingAreaUpdateRequest.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/dto/SmokingAreaUpdateRequest.java
@@ -3,23 +3,37 @@ package com.ssmoker.smoker.domain.smokingArea.dto;
 import com.ssmoker.smoker.domain.smokingArea.domain.SmokingArea;
 
 public record SmokingAreaUpdateRequest(
-        Boolean hasVentilationSystem,
-        Boolean isClean,
-        Boolean hasTrashBin,
-        Boolean hasChair,
-        Boolean isAccessible,
+        Boolean hasAirPurifier,
         Boolean hasAirConditioning,
-        Boolean isOutdoor
+        Boolean hasChair,
+        Boolean hasTrashBin,
+        Boolean hasVentilationSystem,
+        Boolean isAccessible,
+        Boolean hasCCTV,
+        Boolean hasEmergencyButton,
+        Boolean hasVoiceGuidance,
+        Boolean hasFireExtinguisher,
+        Boolean isRegularlyCleaned,
+        Boolean hasCigaretteDisposal,
+        Boolean hasSunshade,
+        Boolean hasRainProtection
 ) {
     public static SmokingAreaUpdateRequest of(SmokingArea smokingArea) {
         return new SmokingAreaUpdateRequest(
-                smokingArea.getFeature().getHasVentilationSystem(),
-                smokingArea.getFeature().getIsClean(),
-                smokingArea.getFeature().getHasTrashBin(),
-                smokingArea.getFeature().getHasChair(),
-                smokingArea.getFeature().getIsAccessible(),
+                smokingArea.getFeature().getHasAirPurifier(),
                 smokingArea.getFeature().getHasAirConditioning(),
-                smokingArea.getFeature().getIsOutdoor()
+                smokingArea.getFeature().getHasChair(),
+                smokingArea.getFeature().getHasTrashBin(),
+                smokingArea.getFeature().getHasVentilationSystem(),
+                smokingArea.getFeature().getIsAccessible(),
+                smokingArea.getFeature().getHasCCTV(),
+                smokingArea.getFeature().getHasEmergencyButton(),
+                smokingArea.getFeature().getHasVoiceGuidance(),
+                smokingArea.getFeature().getHasFireExtinguisher(),
+                smokingArea.getFeature().getIsRegularlyCleaned(),
+                smokingArea.getFeature().getHasCigaretteDisposal(),
+                smokingArea.getFeature().getHasSunshade(),
+                smokingArea.getFeature().getHasRainProtection()
         );
     }
 }

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/dto/SmokingAreaUpdateRequest.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/dto/SmokingAreaUpdateRequest.java
@@ -3,17 +3,23 @@ package com.ssmoker.smoker.domain.smokingArea.dto;
 import com.ssmoker.smoker.domain.smokingArea.domain.SmokingArea;
 
 public record SmokingAreaUpdateRequest(
-        Boolean hasAirConditioning,
-        Boolean hasChair,
+        Boolean hasVentilationSystem,
+        Boolean isClean,
         Boolean hasTrashBin,
-        Boolean isEnclosedSmokingArea
+        Boolean hasChair,
+        Boolean isAccessible,
+        Boolean hasAirConditioning,
+        Boolean isOutdoor
 ) {
     public static SmokingAreaUpdateRequest of(SmokingArea smokingArea) {
         return new SmokingAreaUpdateRequest(
-                smokingArea.getFeature().getHasAirConditioning(),
-                smokingArea.getFeature().getHasChair(),
+                smokingArea.getFeature().getHasVentilationSystem(),
+                smokingArea.getFeature().getIsClean(),
                 smokingArea.getFeature().getHasTrashBin(),
-                smokingArea.getFeature().getIsEnclosedSmokingArea()
+                smokingArea.getFeature().getHasChair(),
+                smokingArea.getFeature().getIsAccessible(),
+                smokingArea.getFeature().getHasAirConditioning(),
+                smokingArea.getFeature().getIsOutdoor()
         );
     }
 }

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/service/SmokingAreaService.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/service/SmokingAreaService.java
@@ -230,24 +230,15 @@ public class SmokingAreaService {
         SmokingArea smokingArea = smokingAreaRepository.findById(smokingAreaId)
                 .orElseThrow(() -> new SmokingAreaNotFoundException(SMOKING_AREA_NOT_FOUND));
 
-        // 새로운 Feature 객체 생성 후 업데이트
-        Feature updatedFeature = new Feature(
-                request.hasVentilationSystem(),
-                request.isClean(),
-                request.hasTrashBin(),
-                request.hasChair(),
-                request.isAccessible(),
-                request.hasAirConditioning(),
-                request.isOutdoor()
-        );
+        Feature updatedFeature = getFeature(request);
         smokingArea.updateFeature(updatedFeature);
 
         smokingArea = smokingAreaRepository.save(smokingArea);
 
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new SmokerNotFoundException(MEMBER_NOT_FOUND));
-
         member.setUpdateCount(member.getUpdateCount() + 1);
+
         memberRepository.save(member);
 
         int updateCount = updatedHistoryRepository.countBySmokingAreaId(smokingAreaId)+1;
@@ -258,6 +249,26 @@ public class SmokingAreaService {
 
         return SmokingAreaUpdateRequest.of(smokingArea);
 
+    }
+
+    private Feature getFeature(SmokingAreaUpdateRequest request) {
+        Feature updatedFeature = new Feature(
+                request.hasAirPurifier(),        // 공기 청정 기능
+                request.hasAirConditioning(),    // 냉난방 기능
+                request.hasChair(),              // 의자 제공
+                request.hasTrashBin(),           // 쓰레기통
+                request.hasVentilationSystem(),  // 환기 시스템
+                request.isAccessible(),          // 휠체어 진입 가능 여부
+                request.hasCCTV(),               // CCTV 설치 여부
+                request.hasEmergencyButton(),    // 비상 버튼
+                request.hasVoiceGuidance(),      // 음성 안내 시스템
+                request.hasFireExtinguisher(),   // 소화기 비치 여부
+                request.isRegularlyCleaned(),    // 정기적인 청소 여부
+                request.hasCigaretteDisposal(),  // 담배꽁초 처리함 제공 여부
+                request.hasSunshade(),           // 햇빛 차단 시설
+                request.hasRainProtection()      // 비바람 차단 시설
+        );
+        return updatedFeature;
     }
 
     public SmokingAreaNameResponse getSmokingAreaName(Long smokingAreaId) {

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/service/SmokingAreaService.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/service/SmokingAreaService.java
@@ -251,26 +251,6 @@ public class SmokingAreaService {
 
     }
 
-    private Feature getFeature(SmokingAreaUpdateRequest request) {
-        Feature updatedFeature = new Feature(
-                request.hasAirPurifier(),        // 공기 청정 기능
-                request.hasAirConditioning(),    // 냉난방 기능
-                request.hasChair(),              // 의자 제공
-                request.hasTrashBin(),           // 쓰레기통
-                request.hasVentilationSystem(),  // 환기 시스템
-                request.isAccessible(),          // 휠체어 진입 가능 여부
-                request.hasCCTV(),               // CCTV 설치 여부
-                request.hasEmergencyButton(),    // 비상 버튼
-                request.hasVoiceGuidance(),      // 음성 안내 시스템
-                request.hasFireExtinguisher(),   // 소화기 비치 여부
-                request.isRegularlyCleaned(),    // 정기적인 청소 여부
-                request.hasCigaretteDisposal(),  // 담배꽁초 처리함 제공 여부
-                request.hasSunshade(),           // 햇빛 차단 시설
-                request.hasRainProtection()      // 비바람 차단 시설
-        );
-        return updatedFeature;
-    }
-
     public SmokingAreaNameResponse getSmokingAreaName(Long smokingAreaId) {
         SmokingArea smokingArea = smokingAreaRepository.findById(smokingAreaId)
                 .orElseThrow(() -> new SmokingAreaNotFoundException(SMOKING_AREA_NOT_FOUND));
@@ -291,10 +271,27 @@ public class SmokingAreaService {
                 smokingArea.getSmokingAreaName(),
                 smokingArea.getLocation().getAddress(),
                 smokingArea.getImageUrl(),
-                smokingArea.getFeature().getHasAirConditioning(),
-                smokingArea.getFeature().getHasChair(),
-                smokingArea.getFeature().getHasTrashBin(),
-                smokingArea.getFeature().getIsEnclosedSmokingArea()
+                smokingArea.getAreaType(),
+                smokingArea.getFeature()
+                );
+    }
+
+    private Feature getFeature(SmokingAreaUpdateRequest request) {
+        return new Feature(
+                request.hasAirPurifier(),        // 공기 청정 기능
+                request.hasAirConditioning(),    // 냉난방 기능
+                request.hasChair(),              // 의자 제공
+                request.hasTrashBin(),           // 쓰레기통
+                request.hasVentilationSystem(),  // 환기 시스템
+                request.isAccessible(),          // 휠체어 진입 가능 여부
+                request.hasCCTV(),               // CCTV 설치 여부
+                request.hasEmergencyButton(),    // 비상 버튼
+                request.hasVoiceGuidance(),      // 음성 안내 시스템
+                request.hasFireExtinguisher(),   // 소화기 비치 여부
+                request.isRegularlyCleaned(),    // 정기적인 청소 여부
+                request.hasCigaretteDisposal(),  // 담배꽁초 처리함 제공 여부
+                request.hasSunshade(),           // 햇빛 차단 시설
+                request.hasRainProtection()      // 비바람 차단 시설
         );
     }
 

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/service/SmokingAreaService.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/service/SmokingAreaService.java
@@ -6,6 +6,7 @@ import static com.ssmoker.smoker.global.exception.code.ErrorStatus.SMOKING_AREA_
 import com.ssmoker.smoker.domain.member.domain.Member;
 import com.ssmoker.smoker.domain.review.repository.ReviewRepository;
 import com.ssmoker.smoker.domain.member.repository.MemberRepository;
+import com.ssmoker.smoker.domain.smokingArea.domain.Feature;
 import com.ssmoker.smoker.domain.smokingArea.domain.SmokingArea;
 import com.ssmoker.smoker.domain.smokingArea.dto.*;
 import com.ssmoker.smoker.domain.smokingArea.exception.SmokingAreaNotFoundException;
@@ -229,10 +230,17 @@ public class SmokingAreaService {
         SmokingArea smokingArea = smokingAreaRepository.findById(smokingAreaId)
                 .orElseThrow(() -> new SmokingAreaNotFoundException(SMOKING_AREA_NOT_FOUND));
 
-        smokingArea.getFeature().setHasAirConditioning(request.hasAirConditioning());
-        smokingArea.getFeature().setHasChair(request.hasChair());
-        smokingArea.getFeature().setHasTrashBin(request.hasTrashBin());
-        smokingArea.getFeature().setIsEnclosedSmokingArea(request.isEnclosedSmokingArea());
+        // 새로운 Feature 객체 생성 후 업데이트
+        Feature updatedFeature = new Feature(
+                request.hasVentilationSystem(),
+                request.isClean(),
+                request.hasTrashBin(),
+                request.hasChair(),
+                request.isAccessible(),
+                request.hasAirConditioning(),
+                request.isOutdoor()
+        );
+        smokingArea.updateFeature(updatedFeature);
 
         smokingArea = smokingAreaRepository.save(smokingArea);
 

--- a/src/main/java/com/ssmoker/smoker/global/security/handler/resolver/AuthUserArgumentResolver.java
+++ b/src/main/java/com/ssmoker/smoker/global/security/handler/resolver/AuthUserArgumentResolver.java
@@ -1,7 +1,5 @@
 package com.ssmoker.smoker.global.security.handler.resolver;
 
-import com.ssmoker.smoker.domain.member.domain.Member;
-import com.ssmoker.smoker.domain.member.service.MemberService;
 import com.ssmoker.smoker.global.security.exception.AuthException;
 import com.ssmoker.smoker.global.exception.code.ErrorStatus;
 import com.ssmoker.smoker.global.security.handler.annotation.AuthUser;


### PR DESCRIPTION
## 작업 내용

> 흡연 구역 컬럼에 시설 형태를 추가하고, 정보 컬럼에 데이터를 추가한다. 

## 참고 사항

> (https://media.discordapp.net/attachments/1309399428624416829/1333680068085416028/image.png?ex=6799c5da&is=6798745a&hm=3723307a22c77e62e3d91e1f8c9d58ef216d35fea55f79900fe517a02a8b31b3&=&format=webp&quality=lossless&width=1044&height=1116)

컬럼 추가하고, 업데이트 코드에 추가된 코드들도 반영되게 수정했습니다 ~~ 

## 연관 이슈

> close #60 


<br>