### PR TITLE
[Refactor] 모달 띄우기 url 토큰 추출 오류 수정하기

### DIFF
--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/controller/SmokingAreaController.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/controller/SmokingAreaController.java
@@ -48,7 +48,7 @@ public class SmokingAreaController {
 
     @Operation(summary = "흡연 구역 마커 클릭(모달)",
             description = "흡연구역 마커 클릭 시 다른 작은 창으로 마커 정보 알려주는 역할")
-    @GetMapping("/{smokingAreaId}/simple")
+    @GetMapping("/simple/{smokingAreaId}")
     public ApiResponse<MapResponse.MarkerResponse> getSmokingAreaMarker(
             @PathVariable(name = "smokingAreaId") Long smokingAreaId,
             @RequestParam(name = "userLat") Double userLat,

--- a/src/main/java/com/ssmoker/smoker/domain/smokingArea/service/SmokingAreaService.java
+++ b/src/main/java/com/ssmoker/smoker/domain/smokingArea/service/SmokingAreaService.java
@@ -7,7 +7,6 @@ import com.ssmoker.smoker.domain.member.domain.Member;
 import com.ssmoker.smoker.domain.review.repository.ReviewRepository;
 import com.ssmoker.smoker.domain.member.repository.MemberRepository;
 import com.ssmoker.smoker.domain.smokingArea.domain.Feature;
-import com.ssmoker.smoker.domain.smokingArea.domain.Location;
 import com.ssmoker.smoker.domain.smokingArea.domain.SmokingArea;
 import com.ssmoker.smoker.domain.smokingArea.dto.*;
 import com.ssmoker.smoker.domain.smokingArea.exception.SmokingAreaNotFoundException;

--- a/src/main/java/com/ssmoker/smoker/global/configuration/SecurityConfig.java
+++ b/src/main/java/com/ssmoker/smoker/global/configuration/SecurityConfig.java
@@ -34,7 +34,11 @@ public class SecurityConfig {
             ALLOW_SMOKING_AREA_URL,
             ALLOW_REVIEW_URL,
             "/api/member/notices",
-            "/api/member/notices/detail/{noticeId}",//공지사항
+            "/api/member/notices/detail/{noticeId}",
+            "/api/smoking-area/simple/{smokingAreaId}",
+            "/api/smoking-area/marker",
+            "/api/smoking-area/list",
+            "/api/smoking-area/search",
             "/test/**",
             //등등 추가 및 수정해주세요
             "/health",

--- a/src/main/java/com/ssmoker/smoker/global/security/filter/JwtRequestFilter.java
+++ b/src/main/java/com/ssmoker/smoker/global/security/filter/JwtRequestFilter.java
@@ -94,7 +94,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 
                 //smokingArea
                 || path.startsWith("/api/smoking-area/marker")
-                || path.startsWith("/api/smoking-area/{smokingAreaId}/simple")
+                || path.startsWith("/api/smoking-area/simple")
                 || path.startsWith("/api/smoking-area/list")
                 || path.startsWith("/api/smoking-area/search")
 
@@ -104,7 +104,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 
                 //Notice
                 || path.startsWith("/api/member/notices")
-                || path.startsWith("/api/member/notices/detail/{noticeId}")
+                || path.startsWith("/api/member/notices/detail")
 
                 // 필요하다면 다른 permitAll 경로들도 추가
                 // ...


### PR DESCRIPTION
## 작업 내용

> 토큰이 필요없는 url의 토큰 추출 실패 오류 수정함

> pathVariable 을 못 읽기 때문에 토큰 패스 url을 읽지 못했던 것 
> => pathVariable을 뒤로 보내는 방식으로 url을 수정
> (/api/smoking-area/{smokingAreaId}/simple -> /api/smoing-area/simple/{smokingAreaId} 로 변경했다는 의미)


## 참고 사항

> 뒤 늦게 url 변경하여 죄송합니다ㅠ

## 연관 이슈

>refactor #79 


<br>