### PR TITLE
[Fix] JwtRequestFilter 수정

### DIFF
--- a/src/main/java/com/ssmoker/smoker/global/security/filter/JwtRequestFilter.java
+++ b/src/main/java/com/ssmoker/smoker/global/security/filter/JwtRequestFilter.java
@@ -97,14 +97,15 @@ public class JwtRequestFilter extends OncePerRequestFilter {
                 || path.startsWith("/test")
 
                 //smokingArea
+                || path.matches("^/api/smoking-area/\\d+$")
                 || path.startsWith("/api/smoking-area/marker")
                 || path.startsWith("/api/smoking-area/simple")
                 || path.startsWith("/api/smoking-area/list")
                 || path.startsWith("/api/smoking-area/search")
 
                 //Review
-                || path.startsWith("/api/reviews/{smokingAreaId}")
-                || path.startsWith("/api/reviews/{smokingAreaId}/starInfo")
+                || path.matches("^/api/reviews/\\d+$")
+                || path.matches("^/api/reviews/\\d+/starInfo$")
 
                 //Notice
                 || path.startsWith("/api/member/notices")


### PR DESCRIPTION
## 작업 내용

>기존 startsWith() 방식에서 동작하지 않는 문제 해결
>`startsWith()` → `matches()` 정규식으로 일부 변경

## 참고 사항

> 

## 연관 이슈

> close #110 


<br>